### PR TITLE
Build from a PATH JDK, and produce the same bytes everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ F-Droid key, so it cannot be installed over an APK from this page — uninstall 
 
 ## Status
 
-Working APK. The source is at 0.2.1, a packaging release that adds the F-Droid material and
-leaves the clock unchanged; the published APK above is 0.2.0. Reference platform:
-Android 4.4 KitKat (API 19).
+Working APK. The source is at 0.2.2; 0.2.1 and 0.2.2 changed only packaging and the build, not the
+clock. The published APK above is 0.2.0. Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions
 

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,7 @@
+A build release. The clock is unchanged.
+
+* The build no longer requires JAVA_HOME. A JDK on PATH is enough, which is what an
+  ordinary distribution install and the F-Droid build server both provide.
+* The APK is now byte-for-byte the same wherever it is built. Zip entries store a local
+  date with no timezone, and the dex entry carried the time of the build, so the same
+  source used to produce different files on different machines.

--- a/scripts/add-to-zip.py
+++ b/scripts/add-to-zip.py
@@ -5,10 +5,18 @@ Usage: scripts/add-to-zip.py <archive> <source-file> <name-in-archive>
 
 The build needs this because aapt2 links resources and the manifest into an APK but cannot add
 classes.dex, and the `zip` command line tool is not present on every build host. Python 3 is.
+
+The entry is stamped with the zip epoch, 1980-01-01, which is what aapt2 already writes for
+everything it puts in the archive. zipfile.write would otherwise copy the file's modification time,
+which is the moment the build ran, and two builds of the same source would differ.
 """
 
 import sys
 import zipfile
+
+# The earliest date the zip format can store. aapt2 uses it for the entries it writes, so using it
+# here keeps every entry in the APK on the same fixed date.
+ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 
 
 def main(argv):
@@ -16,8 +24,14 @@ def main(argv):
         print(__doc__.strip(), file=sys.stderr)
         return 2
     archive, source, name = argv[1], argv[2], argv[3]
+    info = zipfile.ZipInfo(filename=name, date_time=ZIP_EPOCH)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    # zipfile.write would take these from the file on disk; ZipInfo starts them empty.
+    info.external_attr = 0o644 << 16
+    with open(source, "rb") as f:
+        data = f.read()
     with zipfile.ZipFile(archive, "a", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.write(source, name)
+        zf.writestr(info, data)
     return 0
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,13 @@
 
 set -e
 
+# A zip entry stores its timestamp as a local date with no timezone attached. aapt2 writes the
+# fixed 1980-01-01 epoch, but writes it in the builder's local time, so the same source produces
+# different bytes in Seoul and in UTC. Pin the zone and the APK stops depending on where it was
+# built, which is what makes the build reproducible off this machine.
+TZ=UTC
+export TZ
+
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 . "$ROOT/scripts/env.sh"
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -4,7 +4,8 @@
 # Nothing here points at a machine-specific path. Set the variables in the environment, or put
 # them in scripts/env.local.sh (untracked), which this file sources when it exists:
 #
-#   JAVA_HOME          JDK 17 or newer (javac, keytool)
+#   JAVA_HOME          JDK 17 or newer (javac, keytool); when unset, a javac on PATH is used
+#                      and JAVA_HOME is derived from where it lives
 #   ANDROID_SDK_ROOT   Android SDK root (also accepted: ANDROID_HOME)
 #   ANDROID_BUILD_TOOLS_VERSION  build-tools directory name, default 34.0.0
 #   ANDROID_COMPILE_API          platform whose android.jar is compiled against, default 19
@@ -38,11 +39,22 @@ fail() {
 }
 
 require_jdk() {
-    [ -n "${JAVA_HOME:-}" ] || fail "JAVA_HOME is not set (see scripts/env.sh)"
+    # JAVA_HOME wins when it is set. Otherwise fall back to a JDK on PATH, which is what an
+    # ordinary distribution install and the F-Droid build server both give you: javac is there,
+    # the variable is not. keytool and the SDK wrappers are found relative to JAVA_HOME, so it
+    # has to be derived rather than left empty.
+    if [ -z "${JAVA_HOME:-}" ]; then
+        javac_path=$(command -v javac) \
+            || fail "no JDK: set JAVA_HOME, or put javac on PATH (see scripts/env.sh)"
+        # /usr/bin/javac is usually a symlink into the real JDK; resolve it before going up.
+        javac_real=$(readlink -f "$javac_path" 2>/dev/null || printf '%s' "$javac_path")
+        JAVA_HOME=$(dirname "$(dirname "$javac_real")")
+    fi
+
     JAVAC="$JAVA_HOME/bin/javac"
     JAVA="$JAVA_HOME/bin/java"
     KEYTOOL="$JAVA_HOME/bin/keytool"
-    [ -x "$JAVAC" ] || fail "no javac in JAVA_HOME"
+    [ -x "$JAVAC" ] || fail "no javac in JAVA_HOME ($JAVA_HOME)"
     # d8, apksigner and zipalign are shell wrappers that call plain `java`.
     PATH="$JAVA_HOME/bin:$PATH"
     export PATH JAVA_HOME

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="3"
-    android:versionName="0.2.1"
+    android:versionCode="4"
+    android:versionName="0.2.2"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions


### PR DESCRIPTION
The F-Droid build server ran `scripts/build.sh --unsigned` and stopped at `reteclock: JAVA_HOME is not set`. That server has a JDK on `PATH` and does not export the variable; neither does an ordinary distribution install. Requiring it was the same class of problem as hardcoding a path, so this fixes the build rather than adding an `export` line to the F-Droid recipe.

While testing that, the APK turned out not to be reproducible either, for two unrelated reasons. The maintainer has since asked for reproducible builds, so both are fixed here.

## Changes

- `require_jdk` falls back to `javac` on `PATH` and derives `JAVA_HOME` from where it really lives, resolving the symlink first (`/usr/bin/javac` is normally one) because `keytool` and the SDK wrappers are found relative to it. An explicit `JAVA_HOME` still wins. With no JDK at all, the message now names both ways out.
- `build.sh` pins `TZ=UTC`. A zip entry stores a local date with no timezone, and aapt2 writes its fixed 1980 epoch in local time, so a build in Seoul produced `1980-01-01 09:00` and one in UTC `00:00`.
- `add-to-zip.py` stamps `classes.dex` with the same zip epoch instead of the file modification time, which was the moment the build ran. This one meant no two builds ever agreed.
- 0.2.2, version code 4, with `changelogs/4.txt`.

## Verification

- **T006** (new): builds with `JAVA_HOME` unset and the JDK only on `PATH`; and with no JDK anywhere it fails with a message naming both `JAVA_HOME` and `PATH`. 4/4, red first.
- **T007** (new): builds under `Asia/Seoul`, `UTC` and `America/Los_Angeles` and compares bytes. 6/6, and confirmed it catches the defect when the `TZ` pin is removed.
- T005 8/8, JVM unit tests 19/19, `project-check` ok, debug build still signs and verifies.
- The app itself is untouched: every entry in the APK has the same content hash as the 0.2.1 build. Only archive metadata changed.
- From a clean clone, built the way F-Droid does (no `JAVA_HOME`, JDK on `PATH`, no `TZ`) and again from a Seoul environment with `JAVA_HOME` set: `e789b9ba…`, byte-identical.

After merge this needs tag `v0.2.2`, and the F-Droid recipe on merge request 44275 needs the new commit hash and version.