### PR TITLE
Point the download at 0.2.2, and say the F-Droid build is reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,21 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.2.0.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.2.0.apk)** — 58 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.2.2.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.2.2.apk)** — 58 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
 
-An F-Droid listing is in preparation; the repository now carries everything F-Droid builds from.
-See [`docs/fdroid/README.md`](docs/fdroid/README.md). Note that an F-Droid build is signed with the
-F-Droid key, so it cannot be installed over an APK from this page — uninstall first.
+An F-Droid listing is in preparation. See [`docs/fdroid/README.md`](docs/fdroid/README.md). The
+F-Droid build is a [reproducible build](https://f-droid.org/docs/Reproducible_Builds): F-Droid
+compiles the app from source on its own server, checks the result against the APK on this page, and
+ships this exact file. Both carry the same signature, so you can move between them without
+uninstalling.
 
 ## Status
 
-Working APK. The source is at 0.2.2; 0.2.1 and 0.2.2 changed only packaging and the build, not the
-clock. The published APK above is 0.2.0. Reference platform: Android 4.4 KitKat (API 19).
+Working APK, version 0.2.2. 0.2.1 and 0.2.2 changed only packaging and the build, not the clock.
+Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions
 

--- a/docs/fdroid/README.md
+++ b/docs/fdroid/README.md
@@ -87,26 +87,33 @@ and generates the next build block. So a release is:
 2. Add `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`. The file name is the version
    **code**, not the name.
 3. Commit, tag `v<versionName>`, push the tag.
+4. Build with `scripts/build.sh --release` and publish a GitHub release for that tag with the APK
+   named `reteclock-<versionName>.apk`. This is **not** optional any more: `Binaries:` points at
+   that URL and the F-Droid build fails without it.
+5. Update the download link in the README, which names the file explicitly.
 
 No merge request is needed for an ordinary release.
 
 ## Two things to know
 
-**The signature changes.** The F-Droid build is signed with the F-Droid key, not the key used for
-the APKs on the GitHub releases page. Android will not upgrade one to the other in place. Somebody
-running the GitHub APK has to uninstall it before installing the F-Droid one, and loses their
-settings in the process. This is the normal cost of an F-Droid listing.
+**The signature is ours, because this is a reproducible build.** F-Droid compiles the app on its
+own server, compares the result against the APK on the releases page, and ships that file. Both
+downloads carry the same signature, so a phone can move between them without uninstalling.
 
-**Check the signature scheme on the first F-Droid build.** reteclock declares `minSdkVersion 9` and
-requires a v1 (JAR) signature, because Android 2.3 through 6 accept nothing else (requirement R2).
-F-Droid signs with `apksigner`, which decides the schemes from the APK's own `minSdkVersion`, so a
-v1 signature is expected. That has not been confirmed on a real F-Droid-built artifact. The first
-thing to do once the app is published is download it and run:
+Two obligations come with that. Every release needs a signed APK published at
+`releases/download/v<version>/reteclock-<version>.apk`, because `Binaries:` points there and the
+build fails without it. And the signing key has to survive: if it is lost, no future version can
+update an installed reteclock, and `AllowedAPKSigningKeys` cannot be changed to a new one without
+F-Droid treating it as a different app.
+
+**The v1 signature is no longer a risk.** reteclock declares `minSdkVersion 9` and needs a v1 (JAR)
+signature, because Android 2.3 through 6 accept nothing else (requirement R2). Under a reproducible
+build F-Droid ships the APK built here, signed by `scripts/build.sh --release`, which enables v1,
+v2 and v3 explicitly. There is nothing left to hope for. Still worth one check on the first
+published build:
 
 ```sh
 apksigner verify --min-sdk-version 9 --verbose reteclock.apk
 ```
 
-`Verified using v1 scheme (JAR signing): true` is the line that matters. If it is false, the app
-installs on modern Android but not on the old phones it was written for, and that needs raising on
-the merge request.
+`Verified using v1 scheme (JAR signing): true` is the line that matters.

--- a/docs/fdroid/com.reteclock.yml
+++ b/docs/fdroid/com.reteclock.yml
@@ -5,34 +5,42 @@
 # together, and so anyone can see how the F-Droid build is defined without leaving this repo.
 #
 # reteclock has no Gradle, so there is no `gradle:` key. The build block runs the project's own
-# shell build and points `output:` at the unsigned APK it writes. F-Droid signs that APK with the
-# F-Droid key; a build that returns an already-signed APK is rejected, which is why the recipe
-# calls `--unsigned` and never `--release`.
+# shell build and points `output:` at the unsigned APK it writes. `%v` is not expanded there, so it
+# is a glob rather than a file name; `checkupdates` copies the field verbatim into auto-generated
+# builds, and a literal name would go stale at the next release.
+#
+# Binaries + AllowedAPKSigningKeys make this a reproducible build: F-Droid compiles the app on its
+# own server, compares the result against the APK published on the releases page, and on a match
+# ships that file, signed with this project's key rather than F-Droid's. That is only possible
+# because the build is byte-identical wherever it runs - see tests/build/test-reproducible.sh.
+# It also means the signing key must be kept: losing it ends the ability to update the app.
 
 Categories:
-  - Time
+  - Clock
 License: MIT
 AuthorName: reteclock contributors
 SourceCode: https://github.com/rubidus-api/reteclock_apk
 IssueTracker: https://github.com/rubidus-api/reteclock_apk/issues
 Changelog: https://github.com/rubidus-api/reteclock_apk/releases
 
+AutoName: reteclock
+
 RepoType: git
 Repo: https://github.com/rubidus-api/reteclock_apk.git
+Binaries: https://github.com/rubidus-api/reteclock_apk/releases/download/v%v/reteclock-%v.apk
 
-# `commit:` must name a tag whose tree already contains `--unsigned` and `fastlane/`. The older
-# v0.2.0 tag predates both and would fail the build, which is why 0.2.1 exists: it is a packaging
-# release with no change to the clock. Tag v0.2.1 before opening the merge request.
 Builds:
-  - versionName: 0.2.1
-    versionCode: 3
-    commit: v0.2.1
-    output: dist/reteclock-%v-unsigned.apk
+  - versionName: 0.2.2
+    versionCode: 4
+    commit: 665dc627dffc67e13c632c64766be1d0688271ce
+    output: dist/reteclock-*-unsigned.apk
     build:
-      - yes | sdkmanager "platforms;android-19" "build-tools;34.0.0" > /dev/null
+      - sdkmanager "platforms;android-19" "build-tools;34.0.0"
       - scripts/build.sh --unsigned
 
-AutoUpdateMode: Version v%v
+AllowedAPKSigningKeys: 90446b5280aa4ce34bfe8b33252ef6be902c744d4f5af203a5995a4bbd4c641d
+
+AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.2.1
-CurrentVersionCode: 3
+CurrentVersion: 0.2.2
+CurrentVersionCode: 4


### PR DESCRIPTION
Publishing the 0.2.2 release broke the README download link. It named `reteclock-0.2.0.apk` under `releases/latest/download/`, and `latest` had moved to v0.2.2, so the link was returning **404**. Verified before and after.

The F-Droid paragraph was also stale: it said the F-Droid build carries a different signature and cannot be installed over the GitHub APK. With reproducible builds enabled that is no longer true — F-Droid ships the same file, with the same signature.

`docs/fdroid/README.md` gains the obligation that comes with reproducible builds: every release must publish a signed APK at the URL `Binaries:` points to, or the F-Droid build fails, and the signing key has to be kept for the life of the app.

Docs only; no build input changed, so the commit `v0.2.2` points at is untouched.