### PR TITLE
Build with the toolchain F-Droid has: JDK 21, build-tools 35.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Java, Android framework only. Built with the Android SDK command-line tools (`aa
 ## Build
 
 ```sh
-export JAVA_HOME=/path/to/jdk-17
-export ANDROID_SDK_ROOT=/path/to/android-sdk   # build-tools 34.0.0 + platforms;android-19
+export JAVA_HOME=/path/to/jdk-21              # only --release insists on this exact major version
+export ANDROID_SDK_ROOT=/path/to/android-sdk   # build-tools 35.0.0 + platforms;android-19
 
 scripts/build.sh             # dist/reteclock-<version>-debug.apk, signed with a local dev key
 scripts/build.sh --release   # signed with your own release key (RETECLOCK_KEYSTORE)
@@ -119,7 +119,9 @@ scripts/build.sh --unsigned  # dist/reteclock-<version>-unsigned.apk, for F-Droi
 
 `scripts/build.sh` runs `aapt2` → `javac` (source 8, against the API 19 platform) → `d8`
 (`--min-api 9`) → `zipalign` → `apksigner` (v1 + v2 + v3). It needs a JDK, the Android SDK
-command-line tools, and Python 3. Nothing else — no Gradle, no downloads, no dependencies.
+command-line tools, and Python 3. Any JDK will do for a debug build; `--release` requires JDK 21,
+because F-Droid rebuilds the app and compares the result against the published APK, and javac
+versions do not agree on bytecode. Nothing else — no Gradle, no downloads, no dependencies.
 See `scripts/env.sh` for every variable it reads.
 
 This repository publishes only what is needed to build the app, plus this README and its

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,7 @@
+A build release. The clock is unchanged.
+
+* Built with JDK 21 and build-tools 35.0.0, matching what F-Droid uses. The older
+  combination crashed inside d8, and a reproducible build has to use the same
+  toolchain that produced the published APK.
+* A release build now refuses to run under the wrong JDK rather than producing an
+  APK that F-Droid could never verify.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,6 +40,18 @@ case "${1:-}" in
     *)          fail "unknown option: $1 (expected --release or --unsigned)" ;;
 esac
 
+# The F-Droid listing is a reproducible build: F-Droid compiles the app itself and compares the
+# result against the APK published on the releases page. javac 17 and javac 21 emit different
+# bytecode, so a release built with the wrong JDK produces a file F-Droid can never match, and the
+# mismatch would only surface later, in someone else's build log. Refuse here instead.
+# Set RETECLOCK_JDK_MAJOR=any to build a release with a different toolchain on purpose.
+: "${RETECLOCK_JDK_MAJOR:=21}"
+if [ "$MODE" = "release" ] && [ "$RETECLOCK_JDK_MAJOR" != "any" ]; then
+    have=$("$JAVAC" -version 2>&1 | sed -n 's/^javac \([0-9][0-9]*\).*/\1/p')
+    [ "$have" = "$RETECLOCK_JDK_MAJOR" ] || fail \
+        "--release needs JDK $RETECLOCK_JDK_MAJOR, found ${have:-unknown} at $JAVA_HOME; the F-Droid reproducible build compares against this APK (RETECLOCK_JDK_MAJOR=any to override)"
+fi
+
 OUT="$ROOT/build"
 GEN="$OUT/gen"
 CLASSES="$OUT/classes"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -7,7 +7,7 @@
 #   JAVA_HOME          JDK 17 or newer (javac, keytool); when unset, a javac on PATH is used
 #                      and JAVA_HOME is derived from where it lives
 #   ANDROID_SDK_ROOT   Android SDK root (also accepted: ANDROID_HOME)
-#   ANDROID_BUILD_TOOLS_VERSION  build-tools directory name, default 34.0.0
+#   ANDROID_BUILD_TOOLS_VERSION  build-tools directory name, default 35.0.0
 #   ANDROID_COMPILE_API          platform whose android.jar is compiled against, default 19
 #   JUNIT_JAR          junit-platform-console-standalone jar, for scripts/test.sh
 #   RETECLOCK_ROOT     project root, for callers outside scripts/; defaults to the caller's ../
@@ -30,7 +30,7 @@ if [ -f "$ROOT/scripts/env.local.sh" ]; then
 fi
 
 : "${ANDROID_SDK_ROOT:=${ANDROID_HOME:-}}"
-: "${ANDROID_BUILD_TOOLS_VERSION:=34.0.0}"
+: "${ANDROID_BUILD_TOOLS_VERSION:=35.0.0}"
 : "${ANDROID_COMPILE_API:=19}"
 
 fail() {

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="4"
-    android:versionName="0.2.2"
+    android:versionCode="5"
+    android:versionName="0.2.3"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions


### PR DESCRIPTION
F-Droid CI built the app on their server and d8 crashed:

```
Error in .../com/reteclock/SettingsActivity$3.class:
java.lang.NullPointerException: Cannot invoke "String.length()" because "<parameter1>" is null
```

I downloaded a JDK 21 and reproduced it, then narrowed it down rather than guessing:

- Not the JVM d8 runs under. javac 17 classes + d8 on 21 is fine; javac 21 classes + d8 on 17 still fails. It is the class files.
- javac 21 emits a `MethodParameters` attribute on the anonymous inner class constructor whose single mandated parameter has **no name**. R8 8.2.2, shipped in build-tools 34.0.0, reads that name and calls `String.length()` on it.
- build-tools 34.0.0 crashes on javac 21 output; 35.0.0 and 36.0.0 do not. All three are fine with javac 17 output.

The first fix I tried was pinning openjdk-17 in the F-Droid recipe, so their build would match the JDK 17 that produced the published 0.2.2 APK. Their image does not have openjdk-17 — the `test -d` guard I put in front said so on line one. So the project moves to their toolchain instead.

This matters more than an ordinary build break because the listing is now a **reproducible build**: F-Droid rebuilds the app and compares the result against the APK on the releases page. Whatever compiles here has to be what compiles there.

## Changes

- `scripts/env.sh` defaults to build-tools **35.0.0**.
- `--release` refuses to run unless javac is major version **21**. A release built with the wrong JDK produces an APK F-Droid can never match, and that mismatch would surface days later in someone else’s build log rather than here. `RETECLOCK_JDK_MAJOR=any` overrides it. Debug builds are unaffected — they are never published.
- 0.2.3, version code 5, `changelogs/5.txt`. The clock is untouched.
- README: JDK 21 and build-tools 35.0.0 in the build section, and the download link follows to 0.2.3.

## Verification

- **T008** (new): `--release` fails under JDK 17 with a message naming the JDK it wants, still succeeds under 21, the override works, and a debug build under the wrong JDK is still allowed. 5/5, red first — and the first red run was a false pass caused by `scripts/env.local.sh` putting `JAVA_HOME` back, which the test now hides.
- T005 8/8, T006 4/4, T007 6/6, JVM unit tests 19/19, `project-check` ok.

After merge this needs tag `v0.2.3`, a signed release published for it, and the F-Droid recipe updated.