### PR TITLE
Sign without re-aligning, so the signature fits a rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.2.2.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.2.2.apk)** — 58 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.2.4.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.2.4.apk)** — 58 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
@@ -21,7 +21,7 @@ uninstalling.
 
 ## Status
 
-Working APK, version 0.2.2. 0.2.1 and 0.2.2 changed only packaging and the build, not the clock.
+Working APK, version 0.2.4. Everything since 0.2.0 changed only packaging and the build, not the clock.
 Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,6 @@
+A build release. The clock is unchanged.
+
+* The release APK is signed without re-aligning the archive. apksigner from
+  build-tools 35 rearranges an APK while signing unless told not to, which left the
+  signature unable to fit a rebuild of the same source, and broke the check F-Droid
+  runs to confirm a reproducible build.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -138,7 +138,12 @@ fi
 
 APK="$ROOT/dist/reteclock-$VERSION$SUFFIX.apk"
 
-echo "==> apksigner (v1 + v2 + v3)"
+# --alignment-preserved keeps the archive exactly as zipalign left it. apksigner from build-tools
+# 35 re-aligns while signing unless told not to, and the v2/v3 signatures cover the whole archive,
+# so the signature would no longer fit a rebuild of the same source. F-Droid verifies a
+# reproducible build by copying this signature onto its own build, which then fails with a
+# CHUNKED_SHA256 mismatch. T009 guards this.
+echo "==> apksigner (v1 + v2 + v3, alignment preserved)"
 "$APKSIGNER" sign \
     --ks "$KEYSTORE" \
     --ks-key-alias "$KEY_ALIAS" \
@@ -148,6 +153,7 @@ echo "==> apksigner (v1 + v2 + v3)"
     --v1-signing-enabled true \
     --v2-signing-enabled true \
     --v3-signing-enabled true \
+    --alignment-preserved \
     --out "$APK" \
     "$STAGE/aligned.apk"
 

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="5"
-    android:versionName="0.2.3"
+    android:versionCode="6"
+    android:versionName="0.2.4"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions


### PR DESCRIPTION
F-Droid verifies a reproducible build by rebuilding the app, copying the signature off the published APK onto its own build, and verifying that. On 0.2.3 it failed:

```
APK Signature Scheme v3 signer #1: APK integrity check failed.
CHUNKED_SHA256 digest mismatch.
```

The build itself was fine — the pre-signature artifacts from both machines are byte-identical (`16c90c67…`). The problem is signing: **apksigner from build-tools 35 re-aligns the archive unless `--alignment-preserved` is passed**, and the v2/v3 signatures cover the whole archive, so the signature no longer fitted a rebuild of the same source. build-tools 34 preserved alignment by default, which is exactly why 0.2.2 verified and 0.2.3 did not.

## Changes

- `scripts/build.sh` passes `--alignment-preserved`.
- 0.2.4, version code 6, `changelogs/6.txt`.
- README: the download link and the version line. They were left at 0.2.2 by mistake in #4 — that branch was cut from a stale `origin/main`, so the string replacements silently matched nothing. The link was returning 404 again. Both replacements are asserted this time.

## Verification

- **T009** (new): builds a release, rebuilds unsigned, copies the signature across with `apksigcopier` exactly as fdroidserver does, and verifies. Red first, with the same `CHUNKED_SHA256` error F-Droid reported. 5/5 now. It also asserts the published APK keeps its v1 signature, which Android 2.3–6 require.
- T005 8/8, T006 4/4, T007 6/6, T008 5/5, JVM unit tests 19/19, `project-check` ok.