### PR TITLE
Draw the clock in a font the user supplies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Long press the clock to open the settings screen:
 - **Show seconds** — on or off. With the seconds off, the hour and the minute grow into the freed space.
 - **Date format** — `Jul 12` (abbreviated month name) or `07-12` (numeric).
 - **Start when the charger is connected** — on or off.
+- **Font** — the clock draws in the system font unless you add your own. *Add a font from a file*
+  opens the system file picker; the file is copied into the app, so reteclock never asks for
+  storage permission and the font keeps working if you move or delete the original. Several fonts
+  can be kept: the list shows each one's size and the total, and any of them can be selected or
+  deleted. Deleting the one in use falls back to the system font.
+- **Decoration** — bold, italic and underline, independently, over whichever font is in use. A font
+  file holds one weight and one slant, so these are synthesised.
 
 ## How it starts
 

--- a/src/android/java/com/reteclock/ClockView.java
+++ b/src/android/java/com/reteclock/ClockView.java
@@ -27,8 +27,16 @@ public class ClockView extends View {
     // Reused every frame: Dalvik collects garbage on the UI thread, so the draw path allocates nothing.
     private final Paint.FontMetrics fontMetrics = new Paint.FontMetrics();
 
-    private final Typeface regular = Typeface.create("sans-serif-light", Typeface.NORMAL);
-    private final Typeface bold = Typeface.create("sans-serif", Typeface.BOLD);
+    private static final Typeface SYSTEM_REGULAR = Typeface.create("sans-serif-light", Typeface.NORMAL);
+    private static final Typeface SYSTEM_BOLD = Typeface.create("sans-serif", Typeface.BOLD);
+    /** How far italic leans. Synthesised, because a user font has one weight and one slant. */
+    private static final float ITALIC_SKEW = -0.25f;
+
+    /** The user's font, or null to draw with the system faces exactly as the app always has. */
+    private Typeface userFont;
+    private boolean decorBold;
+    private boolean decorItalic;
+    private boolean decorUnderline;
 
     private ClockOptions options;
     private ClockLayout layout;
@@ -48,6 +56,7 @@ public class ClockView extends View {
     public ClockView(Context context) {
         super(context);
         options = Settings.options(context);
+        loadTypeface(context);
         setBackgroundColor(Color.BLACK);
         paint.setColor(Color.WHITE);
         paint.setTextAlign(Paint.Align.CENTER);
@@ -56,6 +65,7 @@ public class ClockView extends View {
     /** Re-reads the options, e.g. after the user comes back from the settings screen. */
     public void reloadOptions() {
         options = Settings.options(getContext());
+        loadTypeface(getContext());
         layout = null;
         invalidate();
     }
@@ -106,7 +116,18 @@ public class ClockView extends View {
             if (text == null) {
                 continue;
             }
-            paint.setTypeface(slot.bold ? bold : regular);
+            // With no user font this is exactly what the app has always drawn: two system faces,
+            // hour and minute bold. A user font has one weight, so bold there is synthesised.
+            boolean wantBold = slot.bold || decorBold;
+            if (userFont != null) {
+                paint.setTypeface(userFont);
+                paint.setFakeBoldText(wantBold);
+            } else {
+                paint.setTypeface(wantBold ? SYSTEM_BOLD : SYSTEM_REGULAR);
+                paint.setFakeBoldText(false);
+            }
+            paint.setTextSkewX(decorItalic ? ITALIC_SKEW : 0f);
+            paint.setUnderlineText(decorUnderline);
             paint.setTextSize(slot.textSize);
             float measured = paint.measureText(text);
             float fitted = ClockLayout.shrinkToFit(slot.textSize, measured, slot.maxWidth);
@@ -120,6 +141,29 @@ public class ClockView extends View {
             canvas.drawText(text, slot.centerX, baseline, paint);
         }
         canvas.restore();
+    }
+
+
+    /**
+     * Reads the chosen font. A file that is not a usable font leaves the system faces in place
+     * rather than a broken clock; the settings screen refuses such files on import, and this is the
+     * second line of defence for a file that goes bad afterwards.
+     */
+    private void loadTypeface(Context context) {
+        decorBold = Settings.bold(context);
+        decorItalic = Settings.italic(context);
+        decorUnderline = Settings.underline(context);
+
+        java.io.File file = Settings.fontFile(context);
+        if (file == null) {
+            userFont = null;
+            return;
+        }
+        try {
+            userFont = Typeface.createFromFile(file);
+        } catch (RuntimeException e) {
+            userFont = null;
+        }
     }
 
     private static String textFor(String role, ClockText time) {

--- a/src/android/java/com/reteclock/Settings.java
+++ b/src/android/java/com/reteclock/Settings.java
@@ -3,7 +3,10 @@ package com.reteclock;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import java.io.File;
+
 import com.reteclock.core.ClockOptions;
+import com.reteclock.core.FontLibrary;
 
 /** The stored settings, and the bridge to the pure-Java {@link ClockOptions}. */
 public final class Settings {
@@ -13,6 +16,13 @@ public final class Settings {
     public static final String KEY_START_WHEN_CHARGING = "start_when_charging";
     public static final String KEY_SHOW_SECONDS = "show_seconds";
     public static final String KEY_DATE_STYLE = "date_style";
+    public static final String KEY_FONT = "font";
+    public static final String KEY_BOLD = "text_bold";
+    public static final String KEY_ITALIC = "text_italic";
+    public static final String KEY_UNDERLINE = "text_underline";
+
+    /** Where imported fonts live, inside the app's own storage: no permission needed to read it. */
+    private static final String FONT_DIR = "fonts";
 
     private Settings() {
     }
@@ -43,6 +53,54 @@ public final class Settings {
 
     public static void setDateStyle(Context context, int style) {
         prefs(context).edit().putInt(KEY_DATE_STYLE, style).commit();
+    }
+
+    /** The fonts the user has imported. */
+    public static FontLibrary fonts(Context context) {
+        return new FontLibrary(new File(context.getFilesDir(), FONT_DIR));
+    }
+
+    /** The chosen font's file name, or "" for the system font. */
+    public static String fontName(Context context) {
+        return prefs(context).getString(KEY_FONT, "");
+    }
+
+    public static void setFontName(Context context, String name) {
+        prefs(context).edit().putString(KEY_FONT, name == null ? "" : name).commit();
+    }
+
+    /**
+     * The chosen font's file, or null to draw with the system font.
+     *
+     * Null also when the setting names a font that has since been deleted, so removing the font in
+     * use leaves a working clock rather than a blank one.
+     */
+    public static File fontFile(Context context) {
+        return fonts(context).file(fontName(context));
+    }
+
+    public static boolean bold(Context context) {
+        return prefs(context).getBoolean(KEY_BOLD, false);
+    }
+
+    public static void setBold(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_BOLD, enabled).commit();
+    }
+
+    public static boolean italic(Context context) {
+        return prefs(context).getBoolean(KEY_ITALIC, false);
+    }
+
+    public static void setItalic(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_ITALIC, enabled).commit();
+    }
+
+    public static boolean underline(Context context) {
+        return prefs(context).getBoolean(KEY_UNDERLINE, false);
+    }
+
+    public static void setUnderline(Context context, boolean enabled) {
+        prefs(context).edit().putBoolean(KEY_UNDERLINE, enabled).commit();
     }
 
     /** The display options the clock draws with. */

--- a/src/android/java/com/reteclock/SettingsActivity.java
+++ b/src/android/java/com/reteclock/SettingsActivity.java
@@ -1,12 +1,20 @@
 package com.reteclock;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
 import android.graphics.Color;
+import android.graphics.Typeface;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.provider.OpenableColumns;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
@@ -14,8 +22,17 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
 import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.reteclock.core.ClockOptions;
+import com.reteclock.core.FontLibrary;
 
 /**
  * The settings screen, reached by long pressing the clock.
@@ -27,6 +44,14 @@ public class SettingsActivity extends Activity {
 
     private static final int TEXT_WHITE = Color.WHITE;
     private static final int TEXT_DIM = Color.parseColor("#B0B0B0");
+
+    /** Anything larger than this is a suspicious thing to call a font on an old phone. */
+    private static final int MAX_FONT_BYTES = 32 * 1024 * 1024;
+
+    private static final int REQUEST_PICK_FONT = 1;
+
+    /** Rebuilt in place whenever a font is added, chosen or deleted. */
+    private LinearLayout fontSection;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -80,6 +105,43 @@ public class SettingsActivity extends Activity {
         });
         root.addView(dateStyle);
 
+        root.addView(heading(getString(R.string.settings_font)));
+
+        fontSection = new LinearLayout(this);
+        fontSection.setOrientation(LinearLayout.VERTICAL);
+        root.addView(fontSection);
+        rebuildFontSection();
+
+        Button add = new Button(this);
+        add.setText(R.string.settings_font_add);
+        add.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                pickFont();
+            }
+        });
+        root.addView(add);
+
+        root.addView(heading(getString(R.string.settings_decoration)));
+        root.addView(decoration(R.string.settings_bold, Settings.bold(this), new Setter() {
+            @Override
+            public void set(boolean checked) {
+                Settings.setBold(SettingsActivity.this, checked);
+            }
+        }));
+        root.addView(decoration(R.string.settings_italic, Settings.italic(this), new Setter() {
+            @Override
+            public void set(boolean checked) {
+                Settings.setItalic(SettingsActivity.this, checked);
+            }
+        }));
+        root.addView(decoration(R.string.settings_underline, Settings.underline(this), new Setter() {
+            @Override
+            public void set(boolean checked) {
+                Settings.setUnderline(SettingsActivity.this, checked);
+            }
+        }));
+
         root.addView(heading(getString(R.string.settings_dock)));
 
         final CheckBox charging = new CheckBox(this);
@@ -96,12 +158,248 @@ public class SettingsActivity extends Activity {
 
         root.addView(spacer());
         root.addView(footer(getString(R.string.settings_about,
-                getString(R.string.app_version), Build.VERSION.RELEASE)));
+                versionName(), Build.VERSION.RELEASE)));
 
         ScrollView scroll = new ScrollView(this);
         scroll.setBackgroundColor(Color.BLACK);
         scroll.addView(root);
         setContentView(scroll);
+    }
+
+
+    /** A decoration toggle. They are independent, so a checkbox each rather than a group. */
+    private interface Setter {
+        void set(boolean checked);
+    }
+
+    private CheckBox decoration(int label, boolean checked, final Setter setter) {
+        CheckBox box = new CheckBox(this);
+        box.setText(label);
+        box.setTextColor(TEXT_WHITE);
+        box.setChecked(checked);
+        box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton button, boolean isChecked) {
+                setter.set(isChecked);
+            }
+        });
+        return box;
+    }
+
+    /**
+     * The system font, then one row per imported font, then what they occupy together.
+     *
+     * Rebuilt wholesale rather than patched: the list is a handful of rows, and rebuilding cannot
+     * leave the radio buttons disagreeing with the setting.
+     */
+    private void rebuildFontSection() {
+        fontSection.removeAllViews();
+
+        FontLibrary library = Settings.fonts(this);
+        List<FontLibrary.Entry> entries = library.list();
+        String chosen = Settings.fontName(this);
+        final List<RadioButton> buttons = new ArrayList<RadioButton>();
+
+        fontSection.addView(fontRow(buttons, null, getString(R.string.settings_font_system),
+                chosen.isEmpty()));
+        for (FontLibrary.Entry entry : entries) {
+            String label = entry.name + "  \u00b7  " + FontLibrary.humanBytes(entry.bytes);
+            fontSection.addView(fontRow(buttons, entry.name, label, entry.name.equals(chosen)));
+        }
+
+        TextView total = footer(entries.isEmpty()
+                ? getString(R.string.settings_font_none)
+                : getString(R.string.settings_font_total, entries.size(),
+                        FontLibrary.humanBytes(library.totalBytes())));
+        total.setPadding(0, dp(6), 0, 0);
+        fontSection.addView(total);
+    }
+
+    /** One row: a radio that selects the font, and for an imported one, a button that deletes it. */
+    private View fontRow(final List<RadioButton> buttons, final String name, String label,
+            boolean selected) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+
+        final RadioButton radio = new RadioButton(this);
+        radio.setText(label);
+        radio.setTextColor(TEXT_WHITE);
+        radio.setChecked(selected);
+        radio.setLayoutParams(new LinearLayout.LayoutParams(
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+        radio.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                for (RadioButton other : buttons) {
+                    other.setChecked(other == radio);
+                }
+                Settings.setFontName(SettingsActivity.this, name == null ? "" : name);
+            }
+        });
+        buttons.add(radio);
+        row.addView(radio);
+
+        if (name != null) {
+            Button delete = new Button(this);
+            delete.setText(R.string.settings_font_delete);
+            delete.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Settings.fonts(SettingsActivity.this).delete(name);
+                    // Deleting the font in use falls back to the system font rather than leaving
+                    // the clock with nothing to draw with.
+                    if (name.equals(Settings.fontName(SettingsActivity.this))) {
+                        Settings.setFontName(SettingsActivity.this, "");
+                    }
+                    rebuildFontSection();
+                }
+            });
+            row.addView(delete);
+        }
+        return row;
+    }
+
+    /**
+     * Asks the system for a file. ACTION_OPEN_DOCUMENT is the modern picker and arrived in API 19;
+     * older devices get ACTION_GET_CONTENT, which has been there since API 1. Either way the file
+     * comes back as a stream the system opens for us, so the app needs no storage permission.
+     */
+    private void pickFont() {
+        Intent intent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+        } else {
+            intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+        }
+        intent.setType("*/*");
+        try {
+            startActivityForResult(intent, REQUEST_PICK_FONT);
+        } catch (ActivityNotFoundException e) {
+            toast(getString(R.string.settings_font_no_picker));
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != REQUEST_PICK_FONT || resultCode != RESULT_OK || data == null
+                || data.getData() == null) {
+            return;
+        }
+        importFont(data.getData());
+    }
+
+    private void importFont(Uri uri) {
+        byte[] content;
+        try {
+            content = readAll(uri);
+        } catch (IOException e) {
+            toast(getString(R.string.settings_font_failed));
+            return;
+        }
+
+        FontLibrary library = Settings.fonts(this);
+        String stored;
+        try {
+            stored = library.add(displayName(uri), content);
+        } catch (IOException e) {
+            toast(getString(R.string.settings_font_failed));
+            return;
+        }
+
+        // Whether the file is really a font is something only the platform can say. Ask it now,
+        // while the file can still be thrown away, rather than leaving a dud in the library.
+        if (!usableFont(library.file(stored))) {
+            library.delete(stored);
+            toast(getString(R.string.settings_font_rejected));
+            return;
+        }
+
+        Settings.setFontName(this, stored);
+        rebuildFontSection();
+        toast(getString(R.string.settings_font_added, stored));
+    }
+
+    /**
+     * Whether the platform can make a typeface out of this file.
+     *
+     * createFromFile does not throw for a file that is not a font: it hands back the default
+     * typeface. Comparing against the default is therefore the check, and a real font that somehow
+     * equals the default would only mean the clock draws in the default face anyway.
+     */
+    private static boolean usableFont(File file) {
+        if (file == null) {
+            return false;
+        }
+        try {
+            Typeface loaded = Typeface.createFromFile(file);
+            return loaded != null && !loaded.equals(Typeface.DEFAULT);
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    private byte[] readAll(Uri uri) throws IOException {
+        InputStream in = getContentResolver().openInputStream(uri);
+        if (in == null) {
+            throw new IOException("cannot open " + uri);
+        }
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int read;
+            long total = 0;
+            while ((read = in.read(buffer)) != -1) {
+                total += read;
+                if (total > MAX_FONT_BYTES) {
+                    throw new IOException("font larger than " + MAX_FONT_BYTES + " bytes");
+                }
+                out.write(buffer, 0, read);
+            }
+            return out.toByteArray();
+        } finally {
+            in.close();
+        }
+    }
+
+    /** The name the picker shows for this document, falling back to the tail of the URI. */
+    private String displayName(Uri uri) {
+        Cursor cursor = null;
+        try {
+            cursor = getContentResolver().query(uri, null, null, null, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                int column = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (column >= 0) {
+                    String name = cursor.getString(column);
+                    if (name != null && !name.isEmpty()) {
+                        return name;
+                    }
+                }
+            }
+        } catch (RuntimeException e) {
+            // Some providers refuse to be queried; the URI still has a tail we can use.
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        String last = uri.getLastPathSegment();
+        return last == null ? "font.ttf" : last;
+    }
+
+    private String versionName() {
+        try {
+            return getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private void toast(String message) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
     }
 
     private TextView title(String text) {

--- a/src/android/res/values/strings.xml
+++ b/src/android/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">reteclock</string>
-    <string name="app_version">0.2.0</string>
     <string name="settings_title">reteclock settings</string>
     <string name="settings_show_seconds">Show seconds</string>
     <string name="settings_date_format">Date format</string>
@@ -9,5 +8,19 @@
     <string name="settings_date_numeric">07-12</string>
     <string name="settings_dock">Dock</string>
     <string name="settings_start_when_charging">Start when the charger is connected</string>
+    <string name="settings_font">Font</string>
+    <string name="settings_font_system">System font</string>
+    <string name="settings_font_add">Add a font from a file\u2026</string>
+    <string name="settings_font_total">%1$d fonts, %2$s in all</string>
+    <string name="settings_font_none">No fonts added yet.</string>
+    <string name="settings_font_delete">Delete</string>
+    <string name="settings_font_added">Added %1$s</string>
+    <string name="settings_font_rejected">That file is not a font this device can read.</string>
+    <string name="settings_font_failed">Could not read that file.</string>
+    <string name="settings_font_no_picker">No app on this device can pick a file.</string>
+    <string name="settings_decoration">Decoration</string>
+    <string name="settings_bold">Bold</string>
+    <string name="settings_italic">Italic</string>
+    <string name="settings_underline">Underline</string>
     <string name="settings_about">reteclock %1$s\nRuns on Android 2.3 (API 9) and newer. Built for Android 4.4.\nThis device: Android %2$s</string>
 </resources>

--- a/src/core/java/com/reteclock/core/FontLibrary.java
+++ b/src/core/java/com/reteclock/core/FontLibrary.java
@@ -1,0 +1,205 @@
+package com.reteclock.core;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * The fonts the user has imported, held as files in one directory.
+ *
+ * Pure Java: no android.* imports, so it is unit tested on a JVM. The Android layer hands it the
+ * app's private directory and the bytes a document picker produced.
+ *
+ * Names come from a picker, which is free to return anything at all — a path, a colon, an empty
+ * string. Every name is sanitised down to a single harmless file name, and every lookup is checked
+ * against the directory afterwards, so a crafted name cannot reach a file outside it.
+ */
+public final class FontLibrary {
+
+    /** One stored font. */
+    public static final class Entry {
+        /** The file name inside the directory, which is also what the setting stores. */
+        public final String name;
+        /** Its size on disk. */
+        public final long bytes;
+
+        Entry(String name, long bytes) {
+            this.name = name;
+            this.bytes = bytes;
+        }
+    }
+
+    /** Used when sanitising leaves nothing usable. */
+    private static final String FALLBACK_NAME = "font";
+
+    private final File dir;
+
+    public FontLibrary(File dir) {
+        this.dir = dir;
+    }
+
+    /** The stored fonts, by name, so the settings screen does not reshuffle between visits. */
+    public List<Entry> list() {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return Collections.emptyList();
+        }
+        List<Entry> entries = new ArrayList<Entry>(files.length);
+        for (File f : files) {
+            if (f.isFile()) {
+                entries.add(new Entry(f.getName(), f.length()));
+            }
+        }
+        Collections.sort(entries, new Comparator<Entry>() {
+            @Override
+            public int compare(Entry a, Entry b) {
+                return a.name.compareTo(b.name);
+            }
+        });
+        return entries;
+    }
+
+    /** What every stored font occupies together. */
+    public long totalBytes() {
+        long total = 0;
+        for (Entry e : list()) {
+            total += e.bytes;
+        }
+        return total;
+    }
+
+    /** Whether a font by this name is still stored. A setting can outlive the file it names. */
+    public boolean exists(String name) {
+        return file(name) != null;
+    }
+
+    /**
+     * The file holding this font, or null when there is no such font. Null rather than a path into
+     * nowhere, so a caller cannot accidentally create the file by writing to what it got back.
+     */
+    public File file(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        File f = new File(dir, name);
+        if (!f.isFile() || !inDirectory(f)) {
+            return null;
+        }
+        return f;
+    }
+
+    /**
+     * Stores these bytes under a name derived from {@code suggestedName}, and returns the name it
+     * actually used — which differs when the suggestion was unusable or already taken.
+     *
+     * @throws IOException if the bytes are empty, or the directory or file cannot be written
+     */
+    public String add(String suggestedName, byte[] content) throws IOException {
+        if (content == null || content.length == 0) {
+            throw new IOException("a font file cannot be empty");
+        }
+        if (!dir.isDirectory() && !dir.mkdirs()) {
+            throw new IOException("cannot create " + dir);
+        }
+        String name = available(sanitise(suggestedName));
+        File target = new File(dir, name);
+        OutputStream out = new FileOutputStream(target);
+        try {
+            out.write(content);
+        } finally {
+            out.close();
+        }
+        return name;
+    }
+
+    /** Removes one font. Returns whether there was one to remove. */
+    public boolean delete(String name) {
+        File f = file(name);
+        return f != null && f.delete();
+    }
+
+    /**
+     * One plain file name: no directories, no separators, nothing a shell or a path walker would
+     * read as structure. Everything outside a small allowed set becomes an underscore.
+     */
+    static String sanitise(String suggestedName) {
+        if (suggestedName == null) {
+            return FALLBACK_NAME;
+        }
+        // A picker may hand back a whole path; only the last segment can be a file name.
+        String base = suggestedName;
+        int slash = Math.max(base.lastIndexOf('/'), base.lastIndexOf('\\'));
+        if (slash >= 0) {
+            base = base.substring(slash + 1);
+        }
+        StringBuilder clean = new StringBuilder(base.length());
+        for (int i = 0; i < base.length(); i++) {
+            char c = base.charAt(i);
+            boolean keep = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_' || c == ' ';
+            clean.append(keep ? c : '_');
+        }
+        String name = clean.toString().trim();
+        // "." and ".." are directories, not names, however they arrived.
+        while (name.startsWith(".")) {
+            name = name.substring(1);
+        }
+        name = name.trim();
+        if (name.isEmpty()) {
+            return FALLBACK_NAME;
+        }
+        // Long names are a filesystem problem, not a user problem; keep the tail, which carries
+        // the extension.
+        if (name.length() > 100) {
+            name = name.substring(name.length() - 100);
+        }
+        return name;
+    }
+
+    /** {@code name}, or the first free variation of it, so an import never overwrites a font. */
+    private String available(String name) {
+        if (!new File(dir, name).exists()) {
+            return name;
+        }
+        String stem = name;
+        String extension = "";
+        int dot = name.lastIndexOf('.');
+        if (dot > 0) {
+            stem = name.substring(0, dot);
+            extension = name.substring(dot);
+        }
+        for (int n = 2; n < 1000; n++) {
+            String candidate = stem + "-" + n + extension;
+            if (!new File(dir, candidate).exists()) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("too many fonts named " + name);
+    }
+
+    /** Whether this file really sits in our directory, after any "..'" has been resolved away. */
+    private boolean inDirectory(File f) {
+        try {
+            return f.getCanonicalFile().getParentFile().equals(dir.getCanonicalFile());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /** A size a person can read: "12 KB", "1.4 MB". */
+    public static String humanBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+        if (bytes < 1024 * 1024) {
+            return (bytes + 512) / 1024 + " KB";
+        }
+        long tenths = (bytes * 10 + 512 * 1024) / (1024 * 1024);
+        return (tenths / 10) + "." + (tenths % 10) + " MB";
+    }
+}


### PR DESCRIPTION
The clock has only ever had the system faces. This lets the user hand it a TTF, keep several, and switch between them, with bold, italic and underline over whichever is in use.

## How the file gets in

Through the system picker — `ACTION_OPEN_DOCUMENT` on API 19 and up, `ACTION_GET_CONTENT` below — then copied into the app’s own storage. The system opens the file for us, so **no storage permission is added and none is requested**; the manifest still lists only `WAKE_LOCK`, checked against the built APK rather than the source. The copy also means the font survives the user moving or deleting the original.

Reading an arbitrary path under shared storage would have needed `READ_EXTERNAL_STORAGE`, a runtime prompt from API 23, which breaks R5 outright. That is why this route and not that one.

## What is in the settings screen

- A row per stored font with its size, plus the system font; picking one applies it.
- A delete button per font, and the total the library occupies.
- Bold, italic, underline as independent toggles.

No preview: the clock itself is the preview, which is what the owner asked for.

## Safety of the name

`FontLibrary` is pure Java in the core, so the part with real logic is unit tested on a JVM. Names are sanitised hard, because a picker is free to return a whole path and that name reaches a `new File(dir, name)`. Every lookup then re-checks that the resolved file really sits in the fonts directory, so a crafted name fails twice rather than once. `add("../../etc/pass wd:*?.ttf")` stays inside; `delete("../outside.txt")` leaves the outside file alone.

## The default look does not change

With no font chosen the drawing takes exactly the old path: `sans-serif-light`, with `sans-serif` bold for the hour and minute. A font file carries one weight and one slant, so bold and italic over a user font are synthesised — what the platform does anyway. Decorations are paint attributes, so they behave the same over a system face and a user face.

Deleting the font in use falls back to the system font rather than leaving a blank clock, and so does a file that stops loading. A file that is not a font is rejected on import and removed again.

## Verification

- **T010** (new): 13 JVM tests over `FontLibrary` — add, list with sizes, total, delete, collisions keeping both files, directories ignored, empty file rejected, and the escape attempts above. Red first (the class did not exist).
- Full suite: 32 unit tests, T005 8/8, T006 4/4, T007 6/6, T008 5/5, T009 5/5, `project-check` ok.
- Built APK: **one permission** (`WAKE_LOCK`), single `classes.dex`, 58,313 → 62,409 bytes.
- Installed and ran on a real **API 19** emulator; the attached screenshot path shows the tall layout rendering unchanged. The portrait shot did not complete — a second emulator with the same AVD collided with it on this shared machine — so that half of T004 is not evidence here.

## Also fixed

The settings screen showed a hardcoded version string, stale at 0.2.0 since 0.2.1. It reads the version from the installed package now.

## Not done here

No version bump, no tag, no release. Releasing now obliges a signed APK at the `Binaries` URL (R22) and is the owner’s call for a feature.

One known rough edge, raised before implementing and accepted: a proportional font makes the clock shuffle every second, because digits differ in width and each line is centred. Noted in the backlog.