### PR TITLE
Drift wider and slower, and give every field its own font

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ Long press the clock to open the settings screen:
 - **Start when the charger is connected** — on or off.
 - **Font** — the clock draws in the system font unless you add your own. *Add a font from a file*
   opens the system file picker; the file is copied into the app, so reteclock never asks for
-  storage permission and the font keeps working if you move or delete the original. Several fonts
-  can be kept: the list shows each one's size and the total, and any of them can be selected or
-  deleted. Deleting the one in use falls back to the system font.
+  storage permission and the font keeps working if you move or delete the original. The list shows
+  each font's size and the total they occupy, and any of them can be deleted.
+- **A font for each field** — the hour, the minute, the seconds, the weekday, the month and day,
+  and the year each choose their own font. Sizes stay worked out by the app. Deleting a font that a
+  field is using drops that field back to the system font.
 - **Decoration** — bold, italic and underline, independently, over whichever font is in use. A font
   file holds one weight and one slant, so these are synthesised.
 

--- a/src/android/java/com/reteclock/ClockView.java
+++ b/src/android/java/com/reteclock/ClockView.java
@@ -32,8 +32,8 @@ public class ClockView extends View {
     /** How far italic leans. Synthesised, because a user font has one weight and one slant. */
     private static final float ITALIC_SKEW = -0.25f;
 
-    /** The user's font, or null to draw with the system faces exactly as the app always has. */
-    private Typeface userFont;
+    /** One font per field, null where the system face is wanted. Indexed by role. */
+    private final java.util.Map<String, Typeface> userFonts = new java.util.HashMap<String, Typeface>();
     private boolean decorBold;
     private boolean decorItalic;
     private boolean decorUnderline;
@@ -59,7 +59,8 @@ public class ClockView extends View {
         loadTypeface(context);
         setBackgroundColor(Color.BLACK);
         paint.setColor(Color.WHITE);
-        paint.setTextAlign(Paint.Align.CENTER);
+        // Parts are positioned by their left edge, since a line can be several of them.
+        paint.setTextAlign(Paint.Align.LEFT);
     }
 
     /** Re-reads the options, e.g. after the user comes back from the settings screen. */
@@ -112,33 +113,40 @@ public class ClockView extends View {
         canvas.translate(BurnInShift.offsetX(elapsed, maxShift), BurnInShift.offsetY(elapsed, maxShift));
 
         for (ClockLayout.Slot slot : layout.slots()) {
-            String text = textFor(slot.role, time);
-            if (text == null) {
+            String[] pieces = piecesFor(slot, time);
+            if (pieces == null) {
                 continue;
             }
-            // With no user font this is exactly what the app has always drawn: two system faces,
-            // hour and minute bold. A user font has one weight, so bold there is synthesised.
-            boolean wantBold = slot.bold || decorBold;
-            if (userFont != null) {
-                paint.setTypeface(userFont);
-                paint.setFakeBoldText(wantBold);
-            } else {
-                paint.setTypeface(wantBold ? SYSTEM_BOLD : SYSTEM_REGULAR);
-                paint.setFakeBoldText(false);
-            }
-            paint.setTextSkewX(decorItalic ? ITALIC_SKEW : 0f);
-            paint.setUnderlineText(decorUnderline);
-            paint.setTextSize(slot.textSize);
-            float measured = paint.measureText(text);
-            float fitted = ClockLayout.shrinkToFit(slot.textSize, measured, slot.maxWidth);
-            if (fitted != slot.textSize) {
-                paint.setTextSize(fitted);
+            // A line can be several parts in different fonts, so it is measured as a whole, shrunk
+            // as a whole, and then drawn piece by piece from the left edge of the group.
+            int count = slot.parts.size();
+            float[] widths = new float[count];
+            float total = 0f;
+            for (int i = 0; i < count; i++) {
+                ClockLayout.Part part = slot.parts.get(i);
+                applyStyle(part.role, slot.bold, slot.textSize);
+                widths[i] = paint.measureText(pieces[i]);
+                total += widths[i];
             }
 
-            // Center the glyphs vertically on slot.centerY.
-            paint.getFontMetrics(fontMetrics);
-            float baseline = slot.centerY - (fontMetrics.ascent + fontMetrics.descent) / 2f;
-            canvas.drawText(text, slot.centerX, baseline, paint);
+            float fitted = ClockLayout.shrinkToFit(slot.textSize, total, slot.maxWidth);
+            if (fitted != slot.textSize) {
+                float scale = fitted / slot.textSize;
+                total = 0f;
+                for (int i = 0; i < count; i++) {
+                    widths[i] *= scale;
+                    total += widths[i];
+                }
+            }
+
+            float[] starts = ClockLayout.partOffsets(slot.centerX, widths);
+            for (int i = 0; i < count; i++) {
+                ClockLayout.Part part = slot.parts.get(i);
+                applyStyle(part.role, slot.bold, fitted);
+                paint.getFontMetrics(fontMetrics);
+                float baseline = slot.centerY - (fontMetrics.ascent + fontMetrics.descent) / 2f;
+                canvas.drawText(pieces[i], starts[i], baseline, paint);
+            }
         }
         canvas.restore();
     }
@@ -154,16 +162,65 @@ public class ClockView extends View {
         decorItalic = Settings.italic(context);
         decorUnderline = Settings.underline(context);
 
-        java.io.File file = Settings.fontFile(context);
-        if (file == null) {
-            userFont = null;
-            return;
+        userFonts.clear();
+        for (String role : Settings.FONT_ROLES) {
+            java.io.File file = Settings.fontFileFor(context, role);
+            if (file == null) {
+                continue;
+            }
+            try {
+                userFonts.put(role, Typeface.createFromFile(file));
+            } catch (RuntimeException e) {
+                // A file that stops loading leaves that field on the system face rather than
+                // taking the whole clock down.
+            }
         }
-        try {
-            userFont = Typeface.createFromFile(file);
-        } catch (RuntimeException e) {
-            userFont = null;
+    }
+
+
+    /**
+     * The strings for one line, separators included, or null when the line has nothing to show.
+     *
+     * The separator belongs to the part it precedes, so it is drawn in the font of the part before
+     * it — the colon of the time reads as part of the time, not as a piece of the minute.
+     */
+    private static String[] piecesFor(ClockLayout.Slot slot, ClockText time) {
+        int count = slot.parts.size();
+        String[] pieces = new String[count];
+        boolean anything = false;
+        for (int i = 0; i < count; i++) {
+            ClockLayout.Part part = slot.parts.get(i);
+            String text = textFor(part.role, time);
+            if (text == null) {
+                return null;
+            }
+            // The separator is measured and drawn with the part before it, so it goes on the end of
+            // that piece rather than the start of this one.
+            if (i > 0 && !part.separatorBefore.isEmpty()) {
+                pieces[i - 1] = pieces[i - 1] + part.separatorBefore;
+            }
+            pieces[i] = text;
+            anything = anything || !text.isEmpty();
         }
+        return anything ? pieces : null;
+    }
+
+    /** Sets the paint up for one field: its font, its weight, and the decorations. */
+    private void applyStyle(String role, boolean slotBold, float textSize) {
+        Typeface font = userFonts.get(role);
+        boolean wantBold = slotBold || decorBold;
+        // With no font of its own this is exactly what the app has always drawn: two system faces,
+        // hour and minute bold. A user font has one weight, so bold there is synthesised.
+        if (font != null) {
+            paint.setTypeface(font);
+            paint.setFakeBoldText(wantBold);
+        } else {
+            paint.setTypeface(wantBold ? SYSTEM_BOLD : SYSTEM_REGULAR);
+            paint.setFakeBoldText(false);
+        }
+        paint.setTextSkewX(decorItalic ? ITALIC_SKEW : 0f);
+        paint.setUnderlineText(decorUnderline);
+        paint.setTextSize(textSize);
     }
 
     private static String textFor(String role, ClockText time) {

--- a/src/android/java/com/reteclock/Settings.java
+++ b/src/android/java/com/reteclock/Settings.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import java.io.File;
 
+import com.reteclock.core.ClockLayout;
 import com.reteclock.core.ClockOptions;
 import com.reteclock.core.FontLibrary;
 
@@ -60,23 +61,47 @@ public final class Settings {
         return new FontLibrary(new File(context.getFilesDir(), FONT_DIR));
     }
 
-    /** The chosen font's file name, or "" for the system font. */
+    /** The fields that can each carry their own font, in the order the settings screen lists them. */
+    public static final String[] FONT_ROLES = {
+        ClockLayout.ROLE_HOUR,
+        ClockLayout.ROLE_MINUTE,
+        ClockLayout.ROLE_SECOND,
+        ClockLayout.ROLE_WEEKDAY,
+        ClockLayout.ROLE_MONTH_DAY,
+        ClockLayout.ROLE_YEAR,
+    };
+
+    /**
+     * The font chosen for one field, or "" for the system font.
+     *
+     * Before fonts were per-field there was a single choice under KEY_FONT. It is still read as the
+     * starting value for every field, so nobody's setting is lost by upgrading.
+     */
+    public static String fontNameFor(Context context, String role) {
+        return prefs(context).getString(KEY_FONT + "_" + role, fontName(context));
+    }
+
+    public static void setFontNameFor(Context context, String role, String name) {
+        prefs(context).edit().putString(KEY_FONT + "_" + role, name == null ? "" : name).commit();
+    }
+
+    /**
+     * That field's font file, or null to draw it with the system font.
+     *
+     * Null also when the setting names a font that has since been deleted, so removing a font in
+     * use leaves a working clock rather than a blank one.
+     */
+    public static File fontFileFor(Context context, String role) {
+        return fonts(context).file(fontNameFor(context, role));
+    }
+
+    /** The font every field started from, kept only so an existing setting still means something. */
     public static String fontName(Context context) {
         return prefs(context).getString(KEY_FONT, "");
     }
 
     public static void setFontName(Context context, String name) {
         prefs(context).edit().putString(KEY_FONT, name == null ? "" : name).commit();
-    }
-
-    /**
-     * The chosen font's file, or null to draw with the system font.
-     *
-     * Null also when the setting names a font that has since been deleted, so removing the font in
-     * use leaves a working clock rather than a blank one.
-     */
-    public static File fontFile(Context context) {
-        return fonts(context).file(fontName(context));
     }
 
     public static boolean bold(Context context) {

--- a/src/android/java/com/reteclock/SettingsActivity.java
+++ b/src/android/java/com/reteclock/SettingsActivity.java
@@ -14,6 +14,8 @@ import android.provider.OpenableColumns;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -21,6 +23,7 @@ import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.ScrollView;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -50,8 +53,20 @@ public class SettingsActivity extends Activity {
 
     private static final int REQUEST_PICK_FONT = 1;
 
-    /** Rebuilt in place whenever a font is added, chosen or deleted. */
+    /** In the order Settings.FONT_ROLES lists them. */
+    private static final int[] FIELD_LABELS = {
+        R.string.settings_field_hour,
+        R.string.settings_field_minute,
+        R.string.settings_field_second,
+        R.string.settings_field_weekday,
+        R.string.settings_field_month_day,
+        R.string.settings_field_year,
+    };
+
+    /** Rebuilt in place whenever a font is added or deleted. */
     private LinearLayout fontSection;
+    /** The per-field font choices, rebuilt with it because the choices are the stored fonts. */
+    private LinearLayout fieldSection;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -110,7 +125,11 @@ public class SettingsActivity extends Activity {
         fontSection = new LinearLayout(this);
         fontSection.setOrientation(LinearLayout.VERTICAL);
         root.addView(fontSection);
-        rebuildFontSection();
+
+        root.addView(heading(getString(R.string.settings_font_per_field)));
+        fieldSection = new LinearLayout(this);
+        fieldSection.setOrientation(LinearLayout.VERTICAL);
+        root.addView(fieldSection);
 
         Button add = new Button(this);
         add.setText(R.string.settings_font_add);
@@ -160,6 +179,9 @@ public class SettingsActivity extends Activity {
         root.addView(footer(getString(R.string.settings_about,
                 versionName(), Build.VERSION.RELEASE)));
 
+        rebuildFontSection();
+        rebuildFieldSection();
+
         ScrollView scroll = new ScrollView(this);
         scroll.setBackgroundColor(Color.BLACK);
         scroll.addView(root);
@@ -197,14 +219,9 @@ public class SettingsActivity extends Activity {
 
         FontLibrary library = Settings.fonts(this);
         List<FontLibrary.Entry> entries = library.list();
-        String chosen = Settings.fontName(this);
-        final List<RadioButton> buttons = new ArrayList<RadioButton>();
-
-        fontSection.addView(fontRow(buttons, null, getString(R.string.settings_font_system),
-                chosen.isEmpty()));
         for (FontLibrary.Entry entry : entries) {
             String label = entry.name + "  \u00b7  " + FontLibrary.humanBytes(entry.bytes);
-            fontSection.addView(fontRow(buttons, entry.name, label, entry.name.equals(chosen)));
+            fontSection.addView(fontRow(entry.name, label));
         }
 
         TextView total = footer(entries.isEmpty()
@@ -215,48 +232,87 @@ public class SettingsActivity extends Activity {
         fontSection.addView(total);
     }
 
-    /** One row: a radio that selects the font, and for an imported one, a button that deletes it. */
-    private View fontRow(final List<RadioButton> buttons, final String name, String label,
-            boolean selected) {
+    /** One row: the font's name and size, and a button that deletes it. */
+    private View fontRow(final String name, String label) {
         LinearLayout row = new LinearLayout(this);
         row.setOrientation(LinearLayout.HORIZONTAL);
         row.setGravity(Gravity.CENTER_VERTICAL);
 
-        final RadioButton radio = new RadioButton(this);
-        radio.setText(label);
-        radio.setTextColor(TEXT_WHITE);
-        radio.setChecked(selected);
-        radio.setLayoutParams(new LinearLayout.LayoutParams(
+        TextView text = new TextView(this);
+        text.setText(label);
+        text.setTextColor(TEXT_WHITE);
+        text.setLayoutParams(new LinearLayout.LayoutParams(
                 0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
-        radio.setOnClickListener(new View.OnClickListener() {
+        row.addView(text);
+
+        Button delete = new Button(this);
+        delete.setText(R.string.settings_font_delete);
+        delete.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                for (RadioButton other : buttons) {
-                    other.setChecked(other == radio);
-                }
-                Settings.setFontName(SettingsActivity.this, name == null ? "" : name);
+                Settings.fonts(SettingsActivity.this).delete(name);
+                // A field still naming this font falls back to the system face on its own, because
+                // the lookup checks the file is there. Nothing else to clean up.
+                rebuildFontSection();
+                rebuildFieldSection();
             }
         });
-        buttons.add(radio);
-        row.addView(radio);
+        row.addView(delete);
+        return row;
+    }
 
-        if (name != null) {
-            Button delete = new Button(this);
-            delete.setText(R.string.settings_font_delete);
-            delete.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    Settings.fonts(SettingsActivity.this).delete(name);
-                    // Deleting the font in use falls back to the system font rather than leaving
-                    // the clock with nothing to draw with.
-                    if (name.equals(Settings.fontName(SettingsActivity.this))) {
-                        Settings.setFontName(SettingsActivity.this, "");
-                    }
-                    rebuildFontSection();
-                }
-            });
-            row.addView(delete);
+    /** One spinner per field, each offering the system font and every stored font. */
+    private void rebuildFieldSection() {
+        fieldSection.removeAllViews();
+
+        List<String> names = new ArrayList<String>();
+        List<String> labels = new ArrayList<String>();
+        names.add("");
+        labels.add(getString(R.string.settings_font_system));
+        for (FontLibrary.Entry entry : Settings.fonts(this).list()) {
+            names.add(entry.name);
+            labels.add(entry.name);
         }
+
+        for (int i = 0; i < Settings.FONT_ROLES.length; i++) {
+            fieldSection.addView(fieldRow(Settings.FONT_ROLES[i], FIELD_LABELS[i], names, labels));
+        }
+    }
+
+    private View fieldRow(final String role, int label, final List<String> names,
+            List<String> labels) {
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView name = new TextView(this);
+        name.setText(label);
+        name.setTextColor(TEXT_WHITE);
+        name.setLayoutParams(new LinearLayout.LayoutParams(
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+        row.addView(name);
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this,
+                android.R.layout.simple_spinner_item, labels);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        final Spinner spinner = new Spinner(this);
+        spinner.setAdapter(adapter);
+        int selected = names.indexOf(Settings.fontNameFor(this, role));
+        spinner.setSelection(selected < 0 ? 0 : selected);
+        spinner.setLayoutParams(new LinearLayout.LayoutParams(
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1.4f));
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                Settings.setFontNameFor(SettingsActivity.this, role, names.get(position));
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+        row.addView(spinner);
         return row;
     }
 
@@ -318,8 +374,8 @@ public class SettingsActivity extends Activity {
             return;
         }
 
-        Settings.setFontName(this, stored);
         rebuildFontSection();
+        rebuildFieldSection();
         toast(getString(R.string.settings_font_added, stored));
     }
 

--- a/src/android/res/values/strings.xml
+++ b/src/android/res/values/strings.xml
@@ -10,6 +10,13 @@
     <string name="settings_start_when_charging">Start when the charger is connected</string>
     <string name="settings_font">Font</string>
     <string name="settings_font_system">System font</string>
+    <string name="settings_font_per_field">A font for each field</string>
+    <string name="settings_field_hour">Hour</string>
+    <string name="settings_field_minute">Minute</string>
+    <string name="settings_field_second">Seconds</string>
+    <string name="settings_field_weekday">Weekday</string>
+    <string name="settings_field_month_day">Month and day</string>
+    <string name="settings_field_year">Year</string>
     <string name="settings_font_add">Add a font from a file\u2026</string>
     <string name="settings_font_total">%1$d fonts, %2$s in all</string>
     <string name="settings_font_none">No fonts added yet.</string>

--- a/src/core/java/com/reteclock/core/BurnInShift.java
+++ b/src/core/java/com/reteclock/core/BurnInShift.java
@@ -3,27 +3,40 @@ package com.reteclock.core;
 /**
  * OLED burn-in protection.
  *
- * The whole drawing is translated by a small offset that walks a closed path: the angle advances
- * one step of a full turn each minute while the radius cycles through three values, so the offsets
- * spread over a small disc instead of retracing a single ring. Every position in a cycle is
+ * The whole drawing is translated by an offset that walks a closed path: the angle advances one
+ * step of a full turn each time the position changes, while the radius cycles through three values,
+ * so the offsets spread over a disc instead of retracing a single ring. Every position in a cycle is
  * distinct, consecutive positions are close together, and the path returns to its start after
  * {@link #STEPS} steps.
+ *
+ * The disc is deliberately wide and walked slowly: a wider spread wears the panel more evenly, and
+ * a slow walk keeps the drift from being something you notice. Widening alone would make each move
+ * a bigger jump, so the number of positions grew with the radius rather than staying put.
+ *
+ * How far the drawing may move is bounded by the padding {@link ClockLayout} reserves, which is
+ * derived from this amplitude, so content cannot be pushed off the screen.
  *
  * Pure Java: no android.* imports.
  */
 public final class BurnInShift {
 
-    /** How long one position is held, in milliseconds. */
-    public static final long STEP_MS = 60000L;
+    /** How long one position is held, in milliseconds. Three minutes: slow enough to go unnoticed. */
+    public static final long STEP_MS = 180000L;
 
-    /** Number of distinct positions in one full cycle. */
-    public static final int STEPS = 24;
+    /**
+     * Number of distinct positions in one full cycle, so a cycle closes after STEPS * STEP_MS —
+     * a little under two and a half hours. A multiple of 3, because the radius cycles through three
+     * values and the path has to close cleanly.
+     */
+    public static final int STEPS = 48;
 
     /** Shift amplitude as a fraction of the shorter screen edge. */
-    private static final float AMPLITUDE_FRACTION = 0.03f;
+    public static final float AMPLITUDE_FRACTION = 0.06f;
 
-    private static final int MIN_SHIFT_PX = 4;
-    private static final int MAX_SHIFT_PX = 32;
+    // Kept at one pixel: a larger floor could exceed the padding on a very small screen, and the
+    // whole point of that padding is that the shift always fits inside it.
+    private static final int MIN_SHIFT_PX = 1;
+    private static final int MAX_SHIFT_PX = 96;
 
     private BurnInShift() {
     }

--- a/src/core/java/com/reteclock/core/ClockLayout.java
+++ b/src/core/java/com/reteclock/core/ClockLayout.java
@@ -44,9 +44,28 @@ public final class ClockLayout {
     public static final String ROLE_WEEKDAY_DATE = "weekday_date";
     public static final String ROLE_SMALL_LINE = "small_line";
 
+    /**
+     * One piece of a line: which field it shows, and what separates it from the piece before it.
+     *
+     * A line can be several pieces so that each field can be drawn in its own font. The separator
+     * is drawn in the font of the part before it, since it belongs to what it follows.
+     */
+    public static final class Part {
+        public final String role;
+        public final String separatorBefore;
+
+        Part(String role, String separatorBefore) {
+            this.role = role;
+            this.separatorBefore = separatorBefore;
+        }
+    }
+
     /** One line of text: what it is, where its center sits, how big it is, whether it is bold. */
     public static final class Slot {
+        /** The line as a whole. Composite lines keep their old role, so callers still recognise them. */
         public final String role;
+        /** The pieces it is drawn from, in order. Always at least one. */
+        public final List<Part> parts;
         /** Center x of the text box, in pixels. */
         public final float centerX;
         /** Center y of the text box, in pixels. */
@@ -58,8 +77,15 @@ public final class ClockLayout {
         /** True for the hour and the minute, which are drawn bold. */
         public final boolean bold;
 
-        Slot(String role, float centerX, float centerY, float textSize, float maxWidth, boolean bold) {
+        Slot(String role, float centerX, float centerY, float textSize, float maxWidth,
+                boolean bold) {
+            this(role, singlePart(role), centerX, centerY, textSize, maxWidth, bold);
+        }
+
+        Slot(String role, List<Part> parts, float centerX, float centerY, float textSize,
+                float maxWidth, boolean bold) {
             this.role = role;
+            this.parts = parts;
             this.centerX = centerX;
             this.centerY = centerY;
             this.textSize = textSize;
@@ -71,8 +97,14 @@ public final class ClockLayout {
     /** Fraction of a wide screen given to the big time block. */
     private static final float WIDE_MAIN_FRACTION = 0.62f;
 
-    /** Padding kept free on every edge, as a fraction of the shorter edge. */
-    private static final float PADDING_FRACTION = 0.04f;
+    /**
+     * Padding kept free on every edge, as a fraction of the shorter edge.
+     *
+     * Derived from the burn-in amplitude rather than chosen independently: the whole drawing is
+     * translated by up to that amplitude, so the padding has to be larger or content would leave
+     * the screen (R14). Widening the shift now widens this with it. T011 asserts the invariant.
+     */
+    private static final float PADDING_FRACTION = BurnInShift.AMPLITUDE_FRACTION * 1.2f;
 
     private final boolean wide;
     private final List<Slot> slots;
@@ -92,6 +124,52 @@ public final class ClockLayout {
         return slots;
     }
 
+    /** One part, for a line that shows a single field. */
+    private static List<Part> singlePart(String role) {
+        List<Part> one = new ArrayList<Part>(1);
+        one.add(new Part(role, ""));
+        return one;
+    }
+
+    /** A line built from several fields, each able to carry its own font. */
+    private static List<Part> parts(String[] roles, String[] separators) {
+        List<Part> out = new ArrayList<Part>(roles.length);
+        for (int i = 0; i < roles.length; i++) {
+            out.add(new Part(roles[i], separators[i]));
+        }
+        return out;
+    }
+
+    /**
+     * Padding kept free on every edge, in pixels.
+     *
+     * Public because the burn-in shift has to stay inside it; T011 checks that it does.
+     */
+    public static float paddingPx(int widthPx, int heightPx) {
+        return Math.min(widthPx, heightPx) * PADDING_FRACTION;
+    }
+
+    /**
+     * Where each part of a line begins, given how wide each one measured.
+     *
+     * The parts sit side by side and the group is centred on {@code centerX}, so a line reads as
+     * one line however its pieces are shaped. Only the view can measure glyphs, so it supplies the
+     * widths and this does the arithmetic — which keeps the arithmetic testable on a JVM.
+     */
+    public static float[] partOffsets(float centerX, float[] widths) {
+        float total = 0f;
+        for (float width : widths) {
+            total += width;
+        }
+        float[] starts = new float[widths.length];
+        float cursor = centerX - total / 2f;
+        for (int i = 0; i < widths.length; i++) {
+            starts[i] = cursor;
+            cursor += widths[i];
+        }
+        return starts;
+    }
+
     /** Builds the layout for a screen of the given pixel size. */
     public static ClockLayout of(int widthPx, int heightPx, ClockOptions options) {
         return widthPx > heightPx
@@ -100,7 +178,7 @@ public final class ClockLayout {
     }
 
     private static ClockLayout wide(int w, int h, ClockOptions options) {
-        float pad = Math.min(w, h) * PADDING_FRACTION;
+        float pad = paddingPx(w, h);
         float mainWidth = w * WIDE_MAIN_FRACTION;
         float sideWidth = w - mainWidth;
         float sideCenterX = mainWidth + sideWidth / 2f;
@@ -110,8 +188,9 @@ public final class ClockLayout {
 
         // The big time takes the full height between the paddings; the view scales it down only if
         // it would be wider than its half of the screen.
-        out.add(new Slot(ROLE_HOUR_MINUTE, mainWidth / 2f, h / 2f,
-                h - 2f * pad, mainWidth - 2f * pad, true));
+        out.add(new Slot(ROLE_HOUR_MINUTE,
+                parts(new String[] {ROLE_HOUR, ROLE_MINUTE}, new String[] {"", ":"}),
+                mainWidth / 2f, h / 2f, h - 2f * pad, mainWidth - 2f * pad, true));
 
         List<String> roles = new ArrayList<String>(4);
         List<Float> sizes = new ArrayList<Float>(4);
@@ -141,7 +220,7 @@ public final class ClockLayout {
     }
 
     private static ClockLayout tall(int w, int h, ClockOptions options) {
-        float pad = Math.min(w, h) * PADDING_FRACTION;
+        float pad = paddingPx(w, h);
         float boxWidth = w - 2f * pad;
         float centerX = w / 2f;
 
@@ -159,9 +238,15 @@ public final class ClockLayout {
         cursor += mainSize + gap;
         out.add(new Slot(ROLE_MINUTE, centerX, cursor + mainSize / 2f, mainSize, boxWidth, true));
         cursor += mainSize + gap;
-        out.add(new Slot(ROLE_WEEKDAY_DATE, centerX, cursor + dateSize / 2f, dateSize, boxWidth, false));
+        out.add(new Slot(ROLE_WEEKDAY_DATE,
+                parts(new String[] {ROLE_WEEKDAY, ROLE_MONTH_DAY}, new String[] {"", ", "}),
+                centerX, cursor + dateSize / 2f, dateSize, boxWidth, false));
         cursor += dateSize + gap;
-        out.add(new Slot(ROLE_SMALL_LINE, centerX, cursor + smallSize / 2f, smallSize, boxWidth, false));
+        List<Part> smallParts = options.showSeconds
+                ? parts(new String[] {ROLE_YEAR, ROLE_SECOND}, new String[] {"", "   "})
+                : singlePart(ROLE_YEAR);
+        out.add(new Slot(ROLE_SMALL_LINE, smallParts,
+                centerX, cursor + smallSize / 2f, smallSize, boxWidth, false));
         return new ClockLayout(false, out);
     }
 


### PR DESCRIPTION
Two requests from the owner: the every-second shuffle under a proportional font does not matter, covering more of the panel does; and the hour, minute, seconds, year, weekday and month-day should each take their own font, with sizes still worked out by the app.

## Burn-in

3% → **6%** of the shorter edge, one minute → **three minutes** a position, 24 → **48** positions, cycle 24 → **144 minutes**. The position count doubled with the radius so a wider disc does not mean a bigger jump.

The amplitude was the easy half. **R14 — never push content off screen — held only because `ClockLayout` reserved 4% and `BurnInShift` used 3%.** Two constants, two classes, a requirement resting on the gap between them, and nothing asserting it. Widening broke that in silence; no test would have caught the clipping.

Padding is derived from the amplitude now, and **T011** asserts the gap across twelve screen sizes. `MIN_SHIFT_PX` dropped to 1, because a larger floor can exceed the padding on a small screen and invert the invariant the padding exists for.

The cost is real: padding went 4% → 7.2%, so the big time is about **7% smaller** than before.

## A font per field

Three lines drew several fields in one `drawText` — `13:45`, `Sun, Jul 12`, `2026   25s` — and one call has one typeface. A slot now carries **ordered parts**, each naming a field and the separator before it. The view measures each part in its own font; `ClockLayout.partOffsets` turns those widths into positions. The line is measured, shrunk and centred **as a whole**, so mixing fonts cannot push it out of its box.

The separator is drawn in the font of the part before it, since it belongs to what it follows.

Settings trades the single font radio list for six spinners. The old single setting is read as each field’s starting value, so nothing anyone chose is lost.

## Verification

- **T011** (new): padding > shift on twelve screen sizes, both orientations, 96×96 to 2560×2560.
- **T012** (new): `partOffsets` centres and orders a group whatever the widths; every slot has ≥1 part; the composite lines split into the fields a user can style; seconds off leaves the year alone.
- Two existing tests encoded the old constants and now assert relationships instead — the amplitude test derives from `AMPLITUDE_FRACTION`, the layout test compares against the height actually left between the paddings.
- 44 unit tests, all five build tests green, `project-check` ok.
- No new permission. Single dex. 62,409 → 66,505 bytes.
- **Android 4.4.2 (API 19)**: installed, ran, no `FATAL EXCEPTION`. Portrait shows the split date and small lines reading as single lines; landscape shows `22:40` with the colon sitting correctly between two separately drawn pieces — which is the thing most likely to have gone wrong.

## Not done here

No version bump, tag or release: that obliges a signed APK at the `Binaries` URL (R22) and is the owner’s call.