### PR TITLE
Size every field from the widest thing it can ever show

### DIFF
--- a/src/android/java/com/reteclock/ClockView.java
+++ b/src/android/java/com/reteclock/ClockView.java
@@ -40,6 +40,13 @@ public class ClockView extends View {
 
     private ClockOptions options;
     private ClockLayout layout;
+    /**
+     * Sizes and cell positions, worked out when the fonts, options or screen change.
+     *
+     * Never rebuilt while drawing: the whole point is that no measurement depends on the time, so
+     * the clock neither resizes nor slides as the digits change.
+     */
+    private ClockLayout.Plan plan;
     private boolean running;
 
     private final Runnable tick = new Runnable() {
@@ -68,6 +75,7 @@ public class ClockView extends View {
         options = Settings.options(getContext());
         loadTypeface(getContext());
         layout = null;
+        plan = null;
         invalidate();
     }
 
@@ -89,7 +97,26 @@ public class ClockView extends View {
     @Override
     protected void onSizeChanged(int w, int h, int oldW, int oldH) {
         super.onSizeChanged(w, h, oldW, oldH);
+        rebuild(w, h);
+    }
+
+
+    /**
+     * Works out the layout and, with it, the sizes and cells every field will use.
+     *
+     * This is the expensive part — it measures every string each field can ever show, in that
+     * field's own font — and it is why the draw path does none of that. Called when the screen size
+     * changes and when the settings do, which is the only time any of it can change.
+     */
+    private void rebuild(int w, int h) {
         layout = ClockLayout.of(w, h, options);
+        plan = layout.plan(new ClockLayout.Metrics() {
+            @Override
+            public float width(String role, boolean bold, String text, float textSize) {
+                applyStyle(role, bold, textSize);
+                return paint.measureText(text);
+            }
+        });
     }
 
     @Override
@@ -101,8 +128,8 @@ public class ClockView extends View {
         if (w <= 0 || h <= 0) {
             return;
         }
-        if (layout == null) {
-            layout = ClockLayout.of(w, h, options);
+        if (layout == null || plan == null) {
+            rebuild(w, h);
         }
 
         ClockText time = ClockText.of(System.currentTimeMillis(), options);
@@ -117,35 +144,19 @@ public class ClockView extends View {
             if (pieces == null) {
                 continue;
             }
-            // A line can be several parts in different fonts, so it is measured as a whole, shrunk
-            // as a whole, and then drawn piece by piece from the left edge of the group.
-            int count = slot.parts.size();
-            float[] widths = new float[count];
-            float total = 0f;
-            for (int i = 0; i < count; i++) {
+            // Everything about size and place was settled when the fonts were. All that is left is
+            // to centre the text of the moment inside the cell reserved for its widest case, so a
+            // narrow reading sits where a wide one would and nothing moves as the clock ticks.
+            float size = plan.textSize(slot);
+            for (int i = 0; i < slot.parts.size(); i++) {
                 ClockLayout.Part part = slot.parts.get(i);
-                applyStyle(part.role, slot.bold, slot.textSize);
-                widths[i] = paint.measureText(pieces[i]);
-                total += widths[i];
-            }
-
-            float fitted = ClockLayout.shrinkToFit(slot.textSize, total, slot.maxWidth);
-            if (fitted != slot.textSize) {
-                float scale = fitted / slot.textSize;
-                total = 0f;
-                for (int i = 0; i < count; i++) {
-                    widths[i] *= scale;
-                    total += widths[i];
-                }
-            }
-
-            float[] starts = ClockLayout.partOffsets(slot.centerX, widths);
-            for (int i = 0; i < count; i++) {
-                ClockLayout.Part part = slot.parts.get(i);
-                applyStyle(part.role, slot.bold, fitted);
+                applyStyle(part.role, slot.bold, size);
+                float cellStart = plan.cellStart(slot, part);
+                float cellWidth = plan.cellWidth(slot, part);
+                float textWidth = paint.measureText(pieces[i]);
                 paint.getFontMetrics(fontMetrics);
                 float baseline = slot.centerY - (fontMetrics.ascent + fontMetrics.descent) / 2f;
-                canvas.drawText(pieces[i], starts[i], baseline, paint);
+                canvas.drawText(pieces[i], cellStart + (cellWidth - textWidth) / 2f, baseline, paint);
             }
         }
         canvas.restore();

--- a/src/core/java/com/reteclock/core/BurnInShift.java
+++ b/src/core/java/com/reteclock/core/BurnInShift.java
@@ -9,9 +9,10 @@ package com.reteclock.core;
  * distinct, consecutive positions are close together, and the path returns to its start after
  * {@link #STEPS} steps.
  *
- * The disc is deliberately wide and walked slowly: a wider spread wears the panel more evenly, and
- * a slow walk keeps the drift from being something you notice. Widening alone would make each move
- * a bigger jump, so the number of positions grew with the radius rather than staying put.
+ * The disc is deliberately wide and walked in many small steps: a wider spread wears the panel more
+ * evenly, and a small step keeps the drift from being something you notice. The step lands on the
+ * minute, when the displayed minute changes anyway, so the movement rides along with a change the
+ * eye is already expecting.
  *
  * How far the drawing may move is bounded by the padding {@link ClockLayout} reserves, which is
  * derived from this amplitude, so content cannot be pushed off the screen.
@@ -20,15 +21,24 @@ package com.reteclock.core;
  */
 public final class BurnInShift {
 
-    /** How long one position is held, in milliseconds. Three minutes: slow enough to go unnoticed. */
-    public static final long STEP_MS = 180000L;
+    /**
+     * How long one position is held. One minute, because the minute digit changes then anyway, so
+     * the drift rides along with a change the eye is already expecting.
+     */
+    public static final long STEP_MS = 60000L;
 
     /**
      * Number of distinct positions in one full cycle, so a cycle closes after STEPS * STEP_MS —
-     * a little under two and a half hours. A multiple of 3, because the radius cycles through three
-     * values and the path has to close cleanly.
+     * 144 minutes. Many positions is what keeps each minute's move tiny while the disc stays wide.
      */
-    public static final int STEPS = 48;
+    public static final int STEPS = 144;
+
+    /** How many times the radius swells and shrinks over one cycle. */
+    private static final int RADIAL_CYCLES = 3;
+
+    /** The radius swings between these fractions of the maximum. */
+    private static final double RADIUS_MIN = 0.4;
+    private static final double RADIUS_MAX = 1.0;
 
     /** Shift amplitude as a fraction of the shorter screen edge. */
     public static final float AMPLITUDE_FRACTION = 0.06f;
@@ -78,11 +88,16 @@ public final class BurnInShift {
     }
 
     /**
-     * Radius for a step: full, then 70%, then 40%, repeating.
+     * Radius for a step: a smooth swell between 40% and 100%, three times around the cycle.
      *
-     * STEPS is a multiple of the radius cycle length, so the whole path closes cleanly.
+     * It used to step between three fixed values, which moved the drawing by a third of the radius
+     * from one position to the next. That was tolerable when a position lasted three minutes; with
+     * a move every minute it would read as a lurch. Varying it smoothly keeps every move small,
+     * and the path still closes because the swell divides the cycle evenly.
      */
     private static double radius(int stepIndex, int maxShiftPx) {
-        return maxShiftPx * (1.0 - 0.3 * (stepIndex % 3));
+        double phase = 2.0 * Math.PI * RADIAL_CYCLES * stepIndex / STEPS;
+        double unit = RADIUS_MIN + (RADIUS_MAX - RADIUS_MIN) * (1.0 + Math.cos(phase)) / 2.0;
+        return maxShiftPx * unit;
     }
 }

--- a/src/core/java/com/reteclock/core/ClockLayout.java
+++ b/src/core/java/com/reteclock/core/ClockLayout.java
@@ -108,10 +108,13 @@ public final class ClockLayout {
 
     private final boolean wide;
     private final List<Slot> slots;
+    /** Kept because which strings a field can show depends on them. */
+    private final ClockOptions options;
 
-    private ClockLayout(boolean wide, List<Slot> slots) {
+    private ClockLayout(boolean wide, List<Slot> slots, ClockOptions options) {
         this.wide = wide;
         this.slots = slots;
+        this.options = options;
     }
 
     /** True when the wide (landscape) arrangement is used. */
@@ -170,6 +173,116 @@ public final class ClockLayout {
         return starts;
     }
 
+    /**
+     * Measures a string for one field at one size. Only the view knows about glyphs.
+     *
+     * Boldness is passed because it changes the width: the hour and the minute are drawn bold, and
+     * measuring them light would size them to something narrower than they are drawn.
+     */
+    public interface Metrics {
+        float width(String role, boolean bold, String text, float textSize);
+    }
+
+    /**
+     * Sizes and cell positions, worked out once from what each field could ever show.
+     *
+     * Nothing here depends on the current time, so nothing about the drawing changes as the clock
+     * ticks: no resize as the digits change width, no sliding as a line gets narrower. Build one
+     * when the fonts, the options or the screen change, and read it every frame.
+     */
+    public static final class Plan {
+        private final java.util.Map<String, Float> sizes = new java.util.HashMap<String, Float>();
+        private final java.util.Map<String, float[]> cells = new java.util.HashMap<String, float[]>();
+
+        private static String key(Slot slot, Part part) {
+            return slot.role + "/" + part.role;
+        }
+
+        /** The size this line is drawn at, small enough that its worst case fits the box. */
+        public float textSize(Slot slot) {
+            Float size = sizes.get(slot.role);
+            return size == null ? slot.textSize : size;
+        }
+
+        /** Where this field's cell begins. The cell does not move as the text inside it changes. */
+        public float cellStart(Slot slot, Part part) {
+            float[] cell = cells.get(key(slot, part));
+            return cell == null ? slot.centerX : cell[0];
+        }
+
+        /** How wide this field's cell is: its own widest content, drawn at {@link #textSize}. */
+        public float cellWidth(Slot slot, Part part) {
+            float[] cell = cells.get(key(slot, part));
+            return cell == null ? 0f : cell[1];
+        }
+    }
+
+    /**
+     * Works out how big each line can be and how much room each field in it needs.
+     *
+     * Each field is measured at its widest — every hour for the hour, every weekday for the weekday
+     * — so a line is sized for the worst case rather than for the moment. A line is then shrunk as a
+     * whole if that worst case does not fit its box, which keeps the fields on one line in step with
+     * each other.
+     */
+    public Plan plan(Metrics metrics) {
+        Plan plan = new Plan();
+        for (Slot slot : slots) {
+            int count = slot.parts.size();
+            float[] widest = new float[count];
+            float total = 0f;
+            for (int i = 0; i < count; i++) {
+                widest[i] = widestPart(slot, slot.parts.get(i), slot.textSize, metrics);
+                total += widest[i];
+            }
+
+            float size = shrinkToFit(slot.textSize, total, slot.maxWidth);
+            if (size != slot.textSize && slot.textSize > 0f) {
+                // Widths scale with the size, so the measured worst case scales with it too. That
+                // saves measuring every candidate twice for a line that had to shrink.
+                float scale = size / slot.textSize;
+                total = 0f;
+                for (int i = 0; i < count; i++) {
+                    widest[i] *= scale;
+                    total += widest[i];
+                }
+            }
+            plan.sizes.put(slot.role, size);
+
+            float cursor = slot.centerX - total / 2f;
+            for (int i = 0; i < count; i++) {
+                plan.cells.put(Plan.key(slot, slot.parts.get(i)), new float[] {cursor, widest[i]});
+                cursor += widest[i];
+            }
+        }
+        return plan;
+    }
+
+    /**
+     * The width of the widest thing this part can ever draw, separator included.
+     *
+     * The separator belongs to the part before it and is drawn in that part's font, so it is
+     * measured as part of it.
+     */
+    private float widestPart(Slot slot, final Part part, final float textSize,
+            final Metrics metrics) {
+        final boolean bold = slot.bold;
+        String trailing = "";
+        List<Part> parts = slot.parts;
+        int index = parts.indexOf(part);
+        if (index >= 0 && index + 1 < parts.size()) {
+            trailing = parts.get(index + 1).separatorBefore;
+        }
+        final String suffix = trailing;
+        return ClockSamples.widest(ClockSamples.of(part.role, options),
+                new ClockSamples.Widths() {
+                    @Override
+                    public float of(String text) {
+                        return metrics.width(part.role, bold, text + suffix, textSize);
+                    }
+                });
+    }
+
     /** Builds the layout for a screen of the given pixel size. */
     public static ClockLayout of(int widthPx, int heightPx, ClockOptions options) {
         return widthPx > heightPx
@@ -216,7 +329,7 @@ public final class ClockLayout {
             out.add(new Slot(roles.get(i), sideCenterX, cursor + size / 2f, size, sideBoxWidth, false));
             cursor += size + lineGap;
         }
-        return new ClockLayout(true, out);
+        return new ClockLayout(true, out, options);
     }
 
     private static ClockLayout tall(int w, int h, ClockOptions options) {
@@ -247,7 +360,7 @@ public final class ClockLayout {
                 : singlePart(ROLE_YEAR);
         out.add(new Slot(ROLE_SMALL_LINE, smallParts,
                 centerX, cursor + smallSize / 2f, smallSize, boxWidth, false));
-        return new ClockLayout(false, out);
+        return new ClockLayout(false, out, options);
     }
 
     /**

--- a/src/core/java/com/reteclock/core/ClockSamples.java
+++ b/src/core/java/com/reteclock/core/ClockSamples.java
@@ -1,0 +1,134 @@
+package com.reteclock.core;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Every string a field can ever show.
+ *
+ * Text sizes are worked out from the widest of these rather than from whatever the clock happens to
+ * be showing, so the size does not change with the time and the layout does not slide. That only
+ * works if this list really is everything: a string a field can produce and this cannot would be
+ * one that gets clipped on somebody's screen and never in a test. T013 checks both directions.
+ *
+ * Pure Java: no android.* imports.
+ */
+public final class ClockSamples {
+
+    /**
+     * The digits worth trying for a number whose value is not otherwise constrained.
+     *
+     * A year is four digits and the clock will be shown in one particular year, but which digits a
+     * font draws widest is the font's business — "1111" is narrow in most faces and "8888" wide, and
+     * some faces reverse it. Trying each digit repeated covers the extremes without enumerating ten
+     * thousand years.
+     */
+    private static final String[] DIGITS = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+
+    private ClockSamples() {
+    }
+
+    /** Everything {@code role} can show, given these options. Empty for a role with no text. */
+    public static List<String> of(String role, ClockOptions options) {
+        if (ClockLayout.ROLE_HOUR.equals(role)) {
+            return twoDigitRange(0, 23);
+        }
+        if (ClockLayout.ROLE_MINUTE.equals(role)) {
+            return twoDigitRange(0, 59);
+        }
+        if (ClockLayout.ROLE_SECOND.equals(role)) {
+            List<String> out = new ArrayList<String>(60);
+            for (String value : twoDigitRange(0, 59)) {
+                out.add(value + "s");
+            }
+            return out;
+        }
+        if (ClockLayout.ROLE_WEEKDAY.equals(role)) {
+            return list(ClockText.WEEKDAYS);
+        }
+        if (ClockLayout.ROLE_MONTH_DAY.equals(role)) {
+            return monthDays(options);
+        }
+        if (ClockLayout.ROLE_YEAR.equals(role)) {
+            List<String> out = new ArrayList<String>(DIGITS.length);
+            for (String digit : DIGITS) {
+                out.add(digit + digit + digit + digit);
+            }
+            return out;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * The widest of these strings under the given measurer, or 0 when there are none.
+     *
+     * Kept here rather than in the caller because "widest sample" is the only thing anyone wants
+     * from a sample list, and doing it in one place keeps the ties broken the same way everywhere.
+     */
+    public static float widest(List<String> samples, Widths widths) {
+        float max = 0f;
+        for (String sample : samples) {
+            float width = widths.of(sample);
+            if (width > max) {
+                max = width;
+            }
+        }
+        return max;
+    }
+
+    /** How wide one string is. The caller knows about fonts; this does not. */
+    public interface Widths {
+        float of(String text);
+    }
+
+    /**
+     * Month and day.
+     *
+     * Under the named style this is a month name and a day number, so the widest is the widest name
+     * beside the widest number — but which pair that is depends on the font, and measuring all 366
+     * combinations to find out would be wasteful. Every month is offered with the two- and
+     * one-digit day extremes, which is 36 strings and covers the pairing that actually wins.
+     *
+     * The numeric style is a fixed shape, so the digits are what vary.
+     */
+    private static List<String> monthDays(ClockOptions options) {
+        List<String> out = new ArrayList<String>();
+        if (options.dateStyle == ClockOptions.DATE_STYLE_NUMERIC) {
+            for (String digit : DIGITS) {
+                out.add(digit + digit + "-" + digit + digit);
+            }
+            // The real range never has a month above 12 or a day above 31, but a font can draw "1"
+            // wider than "9"; these are the shapes that actually occur at the extremes.
+            out.add("12-28");
+            out.add("12-30");
+            out.add("12-31");
+            out.add("11-11");
+            return out;
+        }
+        for (String month : ClockText.MONTHS) {
+            out.add(month + " 1");
+            out.add(month + " 8");
+            out.add(month + " 28");
+            out.add(month + " 30");
+            out.add(month + " 31");
+        }
+        return out;
+    }
+
+    private static List<String> twoDigitRange(int from, int to) {
+        List<String> out = new ArrayList<String>(to - from + 1);
+        for (int value = from; value <= to; value++) {
+            out.add(value < 10 ? "0" + value : String.valueOf(value));
+        }
+        return out;
+    }
+
+    private static List<String> list(String[] values) {
+        List<String> out = new ArrayList<String>(values.length);
+        for (String value : values) {
+            out.add(value);
+        }
+        return out;
+    }
+}

--- a/src/core/java/com/reteclock/core/ClockText.java
+++ b/src/core/java/com/reteclock/core/ClockText.java
@@ -12,11 +12,13 @@ import java.util.TimeZone;
  */
 public final class ClockText {
 
-    private static final String[] WEEKDAYS = {
+    /** Package-visible so {@link ClockSamples} can offer exactly the strings this produces. */
+    static final String[] WEEKDAYS = {
         "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
     };
 
-    private static final String[] MONTHS = {
+    /** As {@link #WEEKDAYS}. */
+    static final String[] MONTHS = {
         "Jan", "Feb", "Mar", "Apr", "May", "Jun",
         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     };


### PR DESCRIPTION
Two requests from the owner.

## The drift moves with the minute

Back to a step a minute — the displayed minute changes then anyway, so the movement rides a change the eye already expects — but **144 positions** instead of 48, so a cycle still takes 144 minutes and each move is a few pixels rather than a jump.

The radius used to step between 100%, 70% and 40%, moving the drawing by a third of the radius at once. Tolerable when a position lasted three minutes; a lurch when it lasts one. It swells smoothly now.

## Sizes come from the worst case, once

Fonts draw the same string at different widths, so a size worked out from the current text changes as the time does. Instead:

- **`ClockSamples`** lists every string a field can produce: all 24 hours, all 60 minutes and seconds, seven weekdays, every month against one- and two-digit days, and each digit repeated for the year — because which digits a font draws widest is the font’s business, and `1111` beats `8888` in some faces and loses in others.
- **`ClockLayout.plan`** measures each field at its widest, sizes the line so that worst case fits, and gives each field a **cell** as wide as its own worst case. The text of the moment is centred inside its cell.

Nothing in a plan depends on the current time, so `11:11` is drawn at the same size and in the same place as `88:88`. The plan is built when the fonts, options or screen change — **the draw path measures nothing**.

Boldness is part of the measurement: the hour and minute are drawn bold, bold is wider, and measuring them light would size them to something narrower than they are drawn.

## Verification

- **T013**: the sample lists, plus the assertion that matters — a walk through a year of real times, every 37 minutes and 13 seconds, checking every rendered field appears in its list. A hand-written list of candidates is exactly the sort of thing that quietly misses a case.
- **T014**: sizes come from the worst case not the current text; every candidate fits its cell; cells are flush and centred; two plans from the same inputs are identical; a wide field shrinks the line rather than stealing its neighbour’s cell; reading a plan measures nothing.
- 59 unit tests, all five build tests, `project-check` ok. No new permission, single dex, 66,505 → 70,601 bytes.
- **API 19, across a minute boundary**: ink stayed exactly 203 px wide as `22:51`/`36s` became `22:52`/`17s` — no resize as the digits changed — and the whole drawing moved by **one pixel**, which is the drift working.

## Not done here

No version bump, tag or release.