### PR TITLE
0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.2.4.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.2.4.apk)** — 58 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.3.0.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.0.apk)** — 69 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
@@ -21,7 +21,7 @@ uninstalling.
 
 ## Status
 
-Working APK, version 0.2.4. Everything since 0.2.0 changed only packaging and the build, not the clock.
+Working APK, version 0.3.0. Reference platform: Android 4.4 KitKat (API 19).
 Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,10 @@
+Your own fonts, and a steadier clock.
+
+* Add fonts from a file. They are kept inside the app, so no storage permission is
+  asked for, and the font survives you moving or deleting the original. Keep several,
+  see what they occupy, delete any of them.
+* The hour, minute, seconds, weekday, month-and-day and year each take their own font.
+* Bold, italic and underline.
+* Every field is now sized from the widest text it could ever show, so the clock no
+  longer resizes or shifts as the digits change. 11:11 sits exactly where 88:88 would.
+* Burn-in protection covers a wider area, moving a few pixels each minute.

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="6"
-    android:versionName="0.2.4"
+    android:versionCode="7"
+    android:versionName="0.3.0"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions


### PR DESCRIPTION
Version 0.3.0, version code 7. The first release since 0.2.0 that changes what the clock does rather than how it is packaged.

- Fonts you supply, through the system file picker, so no storage permission is added.
- A font per field: hour, minute, seconds, weekday, month-and-day, year.
- Bold, italic, underline.
- Sizes come from the widest text a field could ever show, so the clock no longer resizes or slides as the digits change.
- Burn-in protection over a wider area, a few pixels each minute.

Also: the README still claimed 58 KB, from 0.2.0. It is 69 KB.

59 unit tests, all build tests, `project-check` ok.