### PR TITLE
Bold, italic and underline belong to a field, not to the clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ Long press the clock to open the settings screen:
   opens the system file picker; the file is copied into the app, so reteclock never asks for
   storage permission and the font keeps working if you move or delete the original. The list shows
   each font's size and the total they occupy, and any of them can be deleted.
-- **A font for each field** — the hour, the minute, the seconds, the weekday, the month and day,
-  and the year each choose their own font. Sizes stay worked out by the app. Deleting a font that a
-  field is using drops that field back to the system font.
-- **Decoration** — bold, italic and underline, independently, over whichever font is in use. A font
-  file holds one weight and one slant, so these are synthesised.
+- **Each field: font and decoration** — the hour, the minute, the seconds, the weekday, the month
+  and day, and the year each choose their own font and their own bold, italic and underline. Sizes
+  stay worked out by the app. Deleting a font that a field is using drops that field back to the
+  system font. A font file holds one weight and one slant, so bold and italic are synthesised.
 
 ## How it starts
 

--- a/src/android/java/com/reteclock/ClockView.java
+++ b/src/android/java/com/reteclock/ClockView.java
@@ -34,9 +34,10 @@ public class ClockView extends View {
 
     /** One font per field, null where the system face is wanted. Indexed by role. */
     private final java.util.Map<String, Typeface> userFonts = new java.util.HashMap<String, Typeface>();
-    private boolean decorBold;
-    private boolean decorItalic;
-    private boolean decorUnderline;
+    /** Decorations per field, alongside the fonts. Empty means the field carries none. */
+    private final java.util.Set<String> boldRoles = new java.util.HashSet<String>();
+    private final java.util.Set<String> italicRoles = new java.util.HashSet<String>();
+    private final java.util.Set<String> underlineRoles = new java.util.HashSet<String>();
 
     private ClockOptions options;
     private ClockLayout layout;
@@ -169,9 +170,20 @@ public class ClockView extends View {
      * second line of defence for a file that goes bad afterwards.
      */
     private void loadTypeface(Context context) {
-        decorBold = Settings.bold(context);
-        decorItalic = Settings.italic(context);
-        decorUnderline = Settings.underline(context);
+        boldRoles.clear();
+        italicRoles.clear();
+        underlineRoles.clear();
+        for (String role : Settings.FONT_ROLES) {
+            if (Settings.bold(context, role)) {
+                boldRoles.add(role);
+            }
+            if (Settings.italic(context, role)) {
+                italicRoles.add(role);
+            }
+            if (Settings.underline(context, role)) {
+                underlineRoles.add(role);
+            }
+        }
 
         userFonts.clear();
         for (String role : Settings.FONT_ROLES) {
@@ -219,7 +231,7 @@ public class ClockView extends View {
     /** Sets the paint up for one field: its font, its weight, and the decorations. */
     private void applyStyle(String role, boolean slotBold, float textSize) {
         Typeface font = userFonts.get(role);
-        boolean wantBold = slotBold || decorBold;
+        boolean wantBold = slotBold || boldRoles.contains(role);
         // With no font of its own this is exactly what the app has always drawn: two system faces,
         // hour and minute bold. A user font has one weight, so bold there is synthesised.
         if (font != null) {
@@ -229,8 +241,8 @@ public class ClockView extends View {
             paint.setTypeface(wantBold ? SYSTEM_BOLD : SYSTEM_REGULAR);
             paint.setFakeBoldText(false);
         }
-        paint.setTextSkewX(decorItalic ? ITALIC_SKEW : 0f);
-        paint.setUnderlineText(decorUnderline);
+        paint.setTextSkewX(italicRoles.contains(role) ? ITALIC_SKEW : 0f);
+        paint.setUnderlineText(underlineRoles.contains(role));
         paint.setTextSize(textSize);
     }
 

--- a/src/android/java/com/reteclock/Settings.java
+++ b/src/android/java/com/reteclock/Settings.java
@@ -104,28 +104,31 @@ public final class Settings {
         prefs(context).edit().putString(KEY_FONT, name == null ? "" : name).commit();
     }
 
-    public static boolean bold(Context context) {
-        return prefs(context).getBoolean(KEY_BOLD, false);
+    /**
+     * A decoration for one field.
+     *
+     * Before decorations were per-field there was a single flag for the whole clock. It is still
+     * read as the starting value for every field, so nobody's setting is lost by upgrading — the
+     * same arrangement the fonts use.
+     */
+    public static boolean decoration(Context context, String key, String role) {
+        return prefs(context).getBoolean(key + "_" + role, prefs(context).getBoolean(key, false));
     }
 
-    public static void setBold(Context context, boolean enabled) {
-        prefs(context).edit().putBoolean(KEY_BOLD, enabled).commit();
+    public static void setDecoration(Context context, String key, String role, boolean enabled) {
+        prefs(context).edit().putBoolean(key + "_" + role, enabled).commit();
     }
 
-    public static boolean italic(Context context) {
-        return prefs(context).getBoolean(KEY_ITALIC, false);
+    public static boolean bold(Context context, String role) {
+        return decoration(context, KEY_BOLD, role);
     }
 
-    public static void setItalic(Context context, boolean enabled) {
-        prefs(context).edit().putBoolean(KEY_ITALIC, enabled).commit();
+    public static boolean italic(Context context, String role) {
+        return decoration(context, KEY_ITALIC, role);
     }
 
-    public static boolean underline(Context context) {
-        return prefs(context).getBoolean(KEY_UNDERLINE, false);
-    }
-
-    public static void setUnderline(Context context, boolean enabled) {
-        prefs(context).edit().putBoolean(KEY_UNDERLINE, enabled).commit();
+    public static boolean underline(Context context, String role) {
+        return decoration(context, KEY_UNDERLINE, role);
     }
 
     /** The display options the clock draws with. */

--- a/src/android/java/com/reteclock/SettingsActivity.java
+++ b/src/android/java/com/reteclock/SettingsActivity.java
@@ -141,26 +141,6 @@ public class SettingsActivity extends Activity {
         });
         root.addView(add);
 
-        root.addView(heading(getString(R.string.settings_decoration)));
-        root.addView(decoration(R.string.settings_bold, Settings.bold(this), new Setter() {
-            @Override
-            public void set(boolean checked) {
-                Settings.setBold(SettingsActivity.this, checked);
-            }
-        }));
-        root.addView(decoration(R.string.settings_italic, Settings.italic(this), new Setter() {
-            @Override
-            public void set(boolean checked) {
-                Settings.setItalic(SettingsActivity.this, checked);
-            }
-        }));
-        root.addView(decoration(R.string.settings_underline, Settings.underline(this), new Setter() {
-            @Override
-            public void set(boolean checked) {
-                Settings.setUnderline(SettingsActivity.this, checked);
-            }
-        }));
-
         root.addView(heading(getString(R.string.settings_dock)));
 
         final CheckBox charging = new CheckBox(this);
@@ -188,25 +168,6 @@ public class SettingsActivity extends Activity {
         setContentView(scroll);
     }
 
-
-    /** A decoration toggle. They are independent, so a checkbox each rather than a group. */
-    private interface Setter {
-        void set(boolean checked);
-    }
-
-    private CheckBox decoration(int label, boolean checked, final Setter setter) {
-        CheckBox box = new CheckBox(this);
-        box.setText(label);
-        box.setTextColor(TEXT_WHITE);
-        box.setChecked(checked);
-        box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton button, boolean isChecked) {
-                setter.set(isChecked);
-            }
-        });
-        return box;
-    }
 
     /**
      * The system font, then one row per imported font, then what they occupy together.
@@ -279,18 +240,28 @@ public class SettingsActivity extends Activity {
         }
     }
 
+    /**
+     * One field: its name, then its font and its three decorations on the line below.
+     *
+     * Everything about a field sits together, so there is no second section to keep in step with
+     * this one. Two lines rather than one because a spinner and three checkboxes do not fit beside
+     * a label on a narrow phone.
+     */
     private View fieldRow(final String role, int label, final List<String> names,
             List<String> labels) {
-        LinearLayout row = new LinearLayout(this);
-        row.setOrientation(LinearLayout.HORIZONTAL);
-        row.setGravity(Gravity.CENTER_VERTICAL);
+        LinearLayout block = new LinearLayout(this);
+        block.setOrientation(LinearLayout.VERTICAL);
+        block.setPadding(0, dp(8), 0, 0);
 
         TextView name = new TextView(this);
         name.setText(label);
-        name.setTextColor(TEXT_WHITE);
-        name.setLayoutParams(new LinearLayout.LayoutParams(
-                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
-        row.addView(name);
+        name.setTextColor(TEXT_DIM);
+        name.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f);
+        block.addView(name);
+
+        LinearLayout row = new LinearLayout(this);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
 
         ArrayAdapter<String> adapter = new ArrayAdapter<String>(this,
                 android.R.layout.simple_spinner_item, labels);
@@ -301,7 +272,7 @@ public class SettingsActivity extends Activity {
         int selected = names.indexOf(Settings.fontNameFor(this, role));
         spinner.setSelection(selected < 0 ? 0 : selected);
         spinner.setLayoutParams(new LinearLayout.LayoutParams(
-                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1.4f));
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
         spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -313,7 +284,34 @@ public class SettingsActivity extends Activity {
             }
         });
         row.addView(spinner);
-        return row;
+
+        row.addView(toggle(role, Settings.KEY_BOLD, R.string.settings_bold));
+        row.addView(toggle(role, Settings.KEY_ITALIC, R.string.settings_italic));
+        row.addView(toggle(role, Settings.KEY_UNDERLINE, R.string.settings_underline));
+
+        block.addView(row);
+        return block;
+    }
+
+    /**
+     * One decoration toggle for one field.
+     *
+     * A decoration changes how wide the text is — bold is wider, italic leans — so switching one
+     * has to make the clock work its sizes out again. It does: the view drops its plan whenever the
+     * settings change, and rebuilds it by measuring with the decorations applied.
+     */
+    private CheckBox toggle(final String role, final String key, int label) {
+        CheckBox box = new CheckBox(this);
+        box.setText(label);
+        box.setTextColor(TEXT_WHITE);
+        box.setChecked(Settings.decoration(this, key, role));
+        box.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton button, boolean checked) {
+                Settings.setDecoration(SettingsActivity.this, key, role, checked);
+            }
+        });
+        return box;
     }
 
     /**

--- a/src/android/res/values/strings.xml
+++ b/src/android/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="settings_start_when_charging">Start when the charger is connected</string>
     <string name="settings_font">Font</string>
     <string name="settings_font_system">System font</string>
-    <string name="settings_font_per_field">A font for each field</string>
+    <string name="settings_font_per_field">Each field: font and decoration</string>
     <string name="settings_field_hour">Hour</string>
     <string name="settings_field_minute">Minute</string>
     <string name="settings_field_second">Seconds</string>
@@ -25,9 +25,8 @@
     <string name="settings_font_rejected">That file is not a font this device can read.</string>
     <string name="settings_font_failed">Could not read that file.</string>
     <string name="settings_font_no_picker">No app on this device can pick a file.</string>
-    <string name="settings_decoration">Decoration</string>
-    <string name="settings_bold">Bold</string>
-    <string name="settings_italic">Italic</string>
-    <string name="settings_underline">Underline</string>
+    <string name="settings_bold">B</string>
+    <string name="settings_italic">I</string>
+    <string name="settings_underline">U</string>
     <string name="settings_about">reteclock %1$s\nRuns on Android 2.3 (API 9) and newer. Built for Android 4.4.\nThis device: Android %2$s</string>
 </resources>


### PR DESCRIPTION
The fonts were already per field; the decorations were not — turning on italic for the year italicised the hour too. They follow the same arrangement now: a key per role, with the old single flag read as every field’s starting value, so nobody’s setting is lost.

The settings screen loses its **Decoration** section. A field is one block instead — its name, then its font and its three toggles on the line below — so everything about a field sits together and there are not two sections to keep in step.

## The part that would be easy to miss

A decoration changes how wide text is. Bold is wider, italic leans. Sizes and cells are worked out from measured widths, so a decoration has to feed the measurement exactly as a font does. It does — the measuring callback goes through `applyStyle` — and the plan is discarded whenever the settings change, which is what makes the clock resize correctly when a toggle moves.

The hour and minute stay bold regardless of their own bold toggle: that weight belongs to the layout, not to a decoration.

## Verification

No new unit test, and I would rather say so than add one that only re-asserts the settings API. This is settings plumbing and paint attributes; the arithmetic it feeds is already covered by **T014**, which asserts sizes and cells come from measured widths whatever those widths are.

So: the existing 59 unit tests and all five build tests stay green, `project-check` ok, no new permission, and it was checked on a real **API 19** device — underline and bold set on the seconds, italic on the year, nothing on the rest. The screenshot shows `54s` bold and underlined, `2026` italic, and `Sat` and `Aug 1` untouched.

## Not done here

No version bump or tag. Note that with the F-Droid recipe on automatic, pushing a tag publishes there.