### PR TITLE
0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.3.0.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.0.apk)** — 69 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.3.1.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.1.apk)** — 69 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
@@ -21,7 +21,7 @@ uninstalling.
 
 ## Status
 
-Working APK, version 0.3.0. Reference platform: Android 4.4 KitKat (API 19).
+Working APK, version 0.3.1. Reference platform: Android 4.4 KitKat (API 19).
 Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,5 @@
+* Bold, italic and underline are now set for each field on its own, next to that
+  field's font, instead of applying to the whole clock. Whatever you had set before
+  becomes the starting point for every field.
+* Fixed: underlining the year drew the line under the gap that follows it too. The
+  space between two fields now belongs to neither of them.

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="7"
-    android:versionName="0.3.0"
+    android:versionCode="8"
+    android:versionName="0.3.1"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions


### PR DESCRIPTION
Version 0.3.1, version code 8.

- Bold, italic and underline are set per field now, beside that field’s font.
- Fixed: underlining the year drew the line under the gap after it. Whitespace between two fields belongs to neither.

62 unit tests, all build tests, `project-check` ok. Size unchanged at 69 KB.