### PR TITLE
0.3.2: bold is a decoration, and nothing else sets it

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.3.1.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.1.apk)** — 69 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.3.2.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.2.apk)** — 69 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
@@ -21,7 +21,7 @@ uninstalling.
 
 ## Status
 
-Working APK, version 0.3.1. Reference platform: Android 4.4 KitKat (API 19).
+Working APK, version 0.3.2. Reference platform: Android 4.4 KitKat (API 19).
 Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions
@@ -69,8 +69,9 @@ Screenshots taken on Android 4.4.2.
 |---|---|
 | <img src="docs/screenshots/landscape.png" alt="Landscape: bold 23:39 on the left, seconds, weekday, date and year on the right" width="420"> | <img src="docs/screenshots/portrait.png" alt="Portrait: bold hour and minute stacked, weekday with date, year and seconds" width="210"> |
 
-The hour and the minute are bold and take every pixel the other lines do not need. The remaining
-lines are scaled to the space that is left, so nothing is ever clipped. All text is white.
+The hour and the minute take every pixel the other lines do not need. The remaining lines are
+scaled to the space that is left, so nothing is ever clipped. All text is white. Nothing is bold
+unless you set it to be: weight is one of the per-field decorations.
 
 ## Compatibility
 

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,4 @@
+* The hour and the minute are no longer bold by default. Weight now comes only from
+  the bold toggle on that field, so the big time can be light. It used to be that
+  bold could be switched on for those two but never off. What makes the time stand
+  out is its size.

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="8"
-    android:versionName="0.3.1"
+    android:versionCode="9"
+    android:versionName="0.3.2"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions

--- a/src/android/java/com/reteclock/ClockView.java
+++ b/src/android/java/com/reteclock/ClockView.java
@@ -113,8 +113,8 @@ public class ClockView extends View {
         layout = ClockLayout.of(w, h, options);
         plan = layout.plan(new ClockLayout.Metrics() {
             @Override
-            public float width(String role, boolean bold, String text, float textSize) {
-                applyStyle(role, bold, textSize);
+            public float width(String role, String text, float textSize) {
+                applyStyle(role, textSize);
                 return paint.measureText(text);
             }
         });
@@ -151,7 +151,7 @@ public class ClockView extends View {
             float size = plan.textSize(slot);
             for (int i = 0; i < slot.parts.size(); i++) {
                 ClockLayout.Part part = slot.parts.get(i);
-                applyStyle(part.role, slot.bold, size);
+                applyStyle(part.role, size);
                 float cellStart = plan.cellStart(slot, part);
                 float cellWidth = plan.cellWidth(slot, part);
                 float textWidth = paint.measureText(pieces[i]);
@@ -233,13 +233,15 @@ public class ClockView extends View {
         return anything ? pieces : null;
     }
 
-    /** Sets the paint up for one field: its font, its weight, and the decorations. */
-    private void applyStyle(String role, boolean slotBold, float textSize) {
+    /** Sets the paint up for one field: its font and its decorations. */
+    private void applyStyle(String role, float textSize) {
         Typeface font = userFonts.get(role);
-        boolean wantBold = slotBold || boldRoles.contains(role);
-        // With no font of its own this is exactly what the app has always drawn: two system faces,
-        // hour and minute bold. A user font has one weight, so bold there is synthesised.
+        // Weight comes from the field's own bold toggle and from nothing else. The layout used to
+        // make the hour and minute bold whatever the user wanted, which meant bold could be turned
+        // on but never off for the two fields most likely to want a light face.
+        boolean wantBold = boldRoles.contains(role);
         if (font != null) {
+            // A user font has one weight, so bold over it is synthesised.
             paint.setTypeface(font);
             paint.setFakeBoldText(wantBold);
         } else {

--- a/src/core/java/com/reteclock/core/ClockLayout.java
+++ b/src/core/java/com/reteclock/core/ClockLayout.java
@@ -17,14 +17,14 @@ import java.util.List;
  *   +---------------------------+--------------+
  *   |                           |  25s         |
  *   |        13:45              |  Sun         |
- *   |         (bold)            |  Jul 12      |
+ *   |                           |  Jul 12      |
  *   |                           |  2026        |
  *   +---------------------------+--------------+
  *
  * Tall screens (height >= width):
  *
- *   13            (hour, bold)
- *   45            (minute, bold)
+ *   13            (hour)
+ *   45            (minute)
  *   Sun, Jul 12
  *   2026   25s
  *
@@ -71,7 +71,12 @@ public final class ClockLayout {
         }
     }
 
-    /** One line of text: what it is, where its center sits, how big it is, whether it is bold. */
+    /**
+     * One line of text: what it is, where its center sits, and how big it is.
+     *
+     * Deliberately says nothing about weight. Bold is a decoration the user sets per field, so the
+     * layout imposing one would mean two places decided it and the user could not turn it off.
+     */
     public static final class Slot {
         /** The line as a whole. Composite lines keep their old role, so callers still recognise them. */
         public final String role;
@@ -85,23 +90,19 @@ public final class ClockLayout {
         public final float textSize;
         /** Width the text must fit into, in pixels. */
         public final float maxWidth;
-        /** True for the hour and the minute, which are drawn bold. */
-        public final boolean bold;
 
-        Slot(String role, float centerX, float centerY, float textSize, float maxWidth,
-                boolean bold) {
-            this(role, singlePart(role), centerX, centerY, textSize, maxWidth, bold);
+        Slot(String role, float centerX, float centerY, float textSize, float maxWidth) {
+            this(role, singlePart(role), centerX, centerY, textSize, maxWidth);
         }
 
         Slot(String role, List<Part> parts, float centerX, float centerY, float textSize,
-                float maxWidth, boolean bold) {
+                float maxWidth) {
             this.role = role;
             this.parts = parts;
             this.centerX = centerX;
             this.centerY = centerY;
             this.textSize = textSize;
             this.maxWidth = maxWidth;
-            this.bold = bold;
         }
     }
 
@@ -211,11 +212,12 @@ public final class ClockLayout {
     /**
      * Measures a string for one field at one size. Only the view knows about glyphs.
      *
-     * Boldness is passed because it changes the width: the hour and the minute are drawn bold, and
-     * measuring them light would size them to something narrower than they are drawn.
+     * Weight and slant are not passed: they are the user's per-field decorations, and the view
+     * applies the same ones here that it applies when drawing. Measuring under a different weight
+     * from the one drawn would size a field to something narrower than it appears.
      */
     public interface Metrics {
-        float width(String role, boolean bold, String text, float textSize);
+        float width(String role, String text, float textSize);
     }
 
     /**
@@ -287,7 +289,7 @@ public final class ClockLayout {
                 // this field's font changes, and no decoration of it can reach the gap.
                 String space = gapOf(separator);
                 gap[i] = space.isEmpty() ? 0f
-                        : metrics.width(ROLE_GAP, false, space, slot.textSize);
+                        : metrics.width(ROLE_GAP, space, slot.textSize);
                 total += widest[i] + gap[i];
             }
 
@@ -325,12 +327,11 @@ public final class ClockLayout {
      */
     private float widestPart(Slot slot, final Part part, final String suffix,
             final float textSize, final Metrics metrics) {
-        final boolean bold = slot.bold;
         return ClockSamples.widest(ClockSamples.of(part.role, options),
                 new ClockSamples.Widths() {
                     @Override
                     public float of(String text) {
-                        return metrics.width(part.role, bold, text + suffix, textSize);
+                        return metrics.width(part.role, text + suffix, textSize);
                     }
                 });
     }
@@ -355,7 +356,7 @@ public final class ClockLayout {
         // it would be wider than its half of the screen.
         out.add(new Slot(ROLE_HOUR_MINUTE,
                 parts(new String[] {ROLE_HOUR, ROLE_MINUTE}, new String[] {"", ":"}),
-                mainWidth / 2f, h / 2f, h - 2f * pad, mainWidth - 2f * pad, true));
+                mainWidth / 2f, h / 2f, h - 2f * pad, mainWidth - 2f * pad));
 
         List<String> roles = new ArrayList<String>(4);
         List<Float> sizes = new ArrayList<Float>(4);
@@ -378,7 +379,7 @@ public final class ClockLayout {
         float cursor = h / 2f - blockHeight / 2f;
         for (int i = 0; i < sizes.size(); i++) {
             float size = sizes.get(i);
-            out.add(new Slot(roles.get(i), sideCenterX, cursor + size / 2f, size, sideBoxWidth, false));
+            out.add(new Slot(roles.get(i), sideCenterX, cursor + size / 2f, size, sideBoxWidth));
             cursor += size + lineGap;
         }
         return new ClockLayout(true, out, options);
@@ -399,19 +400,19 @@ public final class ClockLayout {
 
         List<Slot> out = new ArrayList<Slot>(4);
         float cursor = pad;
-        out.add(new Slot(ROLE_HOUR, centerX, cursor + mainSize / 2f, mainSize, boxWidth, true));
+        out.add(new Slot(ROLE_HOUR, centerX, cursor + mainSize / 2f, mainSize, boxWidth));
         cursor += mainSize + gap;
-        out.add(new Slot(ROLE_MINUTE, centerX, cursor + mainSize / 2f, mainSize, boxWidth, true));
+        out.add(new Slot(ROLE_MINUTE, centerX, cursor + mainSize / 2f, mainSize, boxWidth));
         cursor += mainSize + gap;
         out.add(new Slot(ROLE_WEEKDAY_DATE,
                 parts(new String[] {ROLE_WEEKDAY, ROLE_MONTH_DAY}, new String[] {"", ", "}),
-                centerX, cursor + dateSize / 2f, dateSize, boxWidth, false));
+                centerX, cursor + dateSize / 2f, dateSize, boxWidth));
         cursor += dateSize + gap;
         List<Part> smallParts = options.showSeconds
                 ? parts(new String[] {ROLE_YEAR, ROLE_SECOND}, new String[] {"", "   "})
                 : singlePart(ROLE_YEAR);
         out.add(new Slot(ROLE_SMALL_LINE, smallParts,
-                centerX, cursor + smallSize / 2f, smallSize, boxWidth, false));
+                centerX, cursor + smallSize / 2f, smallSize, boxWidth));
         return new ClockLayout(false, out, options);
     }
 


### PR DESCRIPTION
The hour and the minute were bold because the layout said so, **and** bold was a per-field decoration the user could set. The two were combined with an OR, so the user’s “off” could never win — bold could be switched on for those two fields but never off, for the two fields most likely to want a light face.

The layout no longer has an opinion about weight. `Slot.bold` is gone, and with it the boolean `Metrics` carried so measurement would match drawing: the view resolves weight from the settings for both now, so passing it separately was not merely unused but misleading.

## The default look changes

Every line is drawn in the light face. What makes the time stand out is that it is far larger than everything else — which is what T003 asserts now, instead of asserting a weight.

## Verification

62 unit tests, all five build tests, `project-check` ok.

On **API 19**: with nothing set, the hour and minute come out light. With bold set on the hour alone, the hour thickens and the minute stays light — so the toggle reaches exactly one field.

Version 0.3.2, version code 9, `changelogs/9.txt`.