### PR TITLE
0.3.3: the hour and minute start bold again, as a default this time

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ it draws so an OLED panel does not burn in.
 
 ## Download
 
-**[⬇ Download reteclock-0.3.2.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.2.apk)** — 69 KB, installs on Android 2.3 and newer.
+**[⬇ Download reteclock-0.3.3.apk](https://github.com/rubidus-api/reteclock_apk/releases/latest/download/reteclock-0.3.3.apk)** — 69 KB, installs on Android 2.3 and newer.
 
 Open the file on the phone to install it. On Android 4.4, enable Settings > Security > Unknown
 sources first. All releases: [Releases](https://github.com/rubidus-api/reteclock_apk/releases).
@@ -21,7 +21,7 @@ uninstalling.
 
 ## Status
 
-Working APK, version 0.3.2. Reference platform: Android 4.4 KitKat (API 19).
+Working APK, version 0.3.3. Reference platform: Android 4.4 KitKat (API 19).
 Reference platform: Android 4.4 KitKat (API 19).
 
 ## Supported Android versions
@@ -70,8 +70,8 @@ Screenshots taken on Android 4.4.2.
 | <img src="docs/screenshots/landscape.png" alt="Landscape: bold 23:39 on the left, seconds, weekday, date and year on the right" width="420"> | <img src="docs/screenshots/portrait.png" alt="Portrait: bold hour and minute stacked, weekday with date, year and seconds" width="210"> |
 
 The hour and the minute take every pixel the other lines do not need. The remaining lines are
-scaled to the space that is left, so nothing is ever clipped. All text is white. Nothing is bold
-unless you set it to be: weight is one of the per-field decorations.
+scaled to the space that is left, so nothing is ever clipped. All text is white. Weight is one of the
+per-field decorations; the hour and the minute have it on to begin with, and you can turn it off.
 
 ## Compatibility
 

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,3 @@
+* The hour and the minute arrive bold again on a fresh install. In 0.3.2 they came out
+  light, which was not what most people would want to see first. The difference from
+  before 0.3.2 is that this is a default you can turn off, not something fixed.

--- a/src/android/AndroidManifest.xml
+++ b/src/android/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.reteclock"
-    android:versionCode="9"
-    android:versionName="0.3.2"
+    android:versionCode="10"
+    android:versionName="0.3.3"
     android:installLocation="auto">
 
     <!-- minSdk 9 keeps very old devices supported; targetSdk 28 keeps current Android versions

--- a/src/android/java/com/reteclock/Settings.java
+++ b/src/android/java/com/reteclock/Settings.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 
 import java.io.File;
 
+import com.reteclock.core.ClockDefaults;
 import com.reteclock.core.ClockLayout;
 import com.reteclock.core.ClockOptions;
 import com.reteclock.core.FontLibrary;
@@ -112,7 +113,22 @@ public final class Settings {
      * same arrangement the fonts use.
      */
     public static boolean decoration(Context context, String key, String role) {
-        return prefs(context).getBoolean(key + "_" + role, prefs(context).getBoolean(key, false));
+        return prefs(context).getBoolean(key + "_" + role, defaultDecoration(context, key, role));
+    }
+
+    /**
+     * What a field's decoration is before anyone has touched it.
+     *
+     * The hour and the minute start bold — see {@link ClockDefaults} — and that ignores the old
+     * single flag, because in the versions that had it those two were drawn bold regardless of what
+     * it said. Everything else falls back to that flag, so a decoration set before there were
+     * per-field ones still means something.
+     */
+    private static boolean defaultDecoration(Context context, String key, String role) {
+        if (KEY_BOLD.equals(key) && ClockDefaults.boldByDefault(role)) {
+            return true;
+        }
+        return prefs(context).getBoolean(key, false);
     }
 
     public static void setDecoration(Context context, String key, String role, boolean enabled) {

--- a/src/core/java/com/reteclock/core/ClockDefaults.java
+++ b/src/core/java/com/reteclock/core/ClockDefaults.java
@@ -1,0 +1,27 @@
+package com.reteclock.core;
+
+/**
+ * What the per-field settings start out as, before the user has touched them.
+ *
+ * Kept apart from {@link ClockLayout} on purpose. The layout used to make the hour and the minute
+ * bold and that was not a default at all — it was combined with the user's own toggle, so bold
+ * could be switched on for those fields but never off. That is gone. What lives here is only a
+ * starting point: the settings screen shows it checked, and unchecking it works like any other.
+ *
+ * Pure Java: no android.* imports.
+ */
+public final class ClockDefaults {
+
+    private ClockDefaults() {
+    }
+
+    /**
+     * Whether this field arrives bold on a fresh install.
+     *
+     * The hour and the minute do, because that is how the clock has looked since the beginning and
+     * it is what makes the time read as the time at a glance. Everything else starts light.
+     */
+    public static boolean boldByDefault(String role) {
+        return ClockLayout.ROLE_HOUR.equals(role) || ClockLayout.ROLE_MINUTE.equals(role);
+    }
+}


### PR DESCRIPTION
0.3.2 took away the layout’s power to make the hour and minute bold — it was ORed with the user’s toggle, so the user’s “off” could never win. That was right, but it left a fresh install drawing the whole clock light, which is not what most people would want to see first.

They start bold again. **The difference from before 0.3.2 is the whole point: this is a default.** The settings screen shows it checked and unchecking it works, where previously the toggle could switch bold on for those two fields but not off.

## Why `ClockDefaults` is its own class

It would have been shorter to put the rule in `ClockLayout`, next to the roles. That is deliberately not where it is. Putting anything about weight back into the layout would blur the line between *the layout decides* and *this is where a setting starts* — the exact distinction 0.3.2 drew. The class name says which of the two it is.

## Migration

The default ignores the single pre-0.3.1 bold flag for the hour and minute, because in the versions that had it those two were drawn bold regardless of what it said. Every other field still falls back to it, so a decoration set before there were per-field ones still means something.

## Verification

- **T015** (new): the hour and minute start bold; the other four start light; an unknown role, a null role and the composite line roles carry no default — those are not fields the user styles, and a default for them would be one nobody could see or change.
- 65 unit tests, all five build tests, `project-check` ok.
- **API 19, from a genuinely clean install** — package removed and `/data/data/com.reteclock` deleted, confirmed no `shared_prefs` existed — the hour and minute come out bold and everything else light.

Version 0.3.3, version code 10.