### PR TITLE
Bring the F-Droid description up to date with the app

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -8,12 +8,15 @@ Features
 
 * Full-screen 24-hour clock with seconds, weekday, month, day and year.
 * Two layouts. Wide screen: a large HH:MM on the left, with seconds, weekday, date and year in a column on the right. Tall screen: hour and minute stacked, then the weekday with the date, then the year and the seconds.
-* The hour and the minute are bold and as large as the screen allows. Space is reserved for the smaller lines first and everything left over goes to the big time, so nothing is ever clipped.
+* The hour and the minute are as large as the screen allows. Space is reserved for the smaller lines first and everything left over goes to the big time, so nothing is ever clipped. They arrive bold, and you can turn that off.
 * Keeps the screen on while the clock is shown.
-* Burn-in protection: the drawing shifts slowly, in small steps, within a few pixels, so an OLED panel does not burn in.
+* Burn-in protection: the drawing moves a few pixels every minute, when the displayed minute changes anyway, and works its way around a wide disc over a couple of hours, so an OLED panel does not burn in.
 * Starts when the charger is connected, and shows over the lock screen when started that way. This can be turned off.
 * Works as a system screensaver (Daydream) on Android 4.2 and newer, and from a desk dock.
-* Settings, opened with a long press on the clock: show seconds on or off, date format (Jul 12 or 07-12), and start-when-charging on or off.
+* Your own fonts. Add a TTF from a file and the clock draws in it. The file goes through the system picker and is copied into the app, so reteclock still asks for no storage permission, and the font keeps working if you move or delete the original. Keep several: the settings screen lists each one's size and the total they occupy, and any of them can be deleted.
+* A font for each field. The hour, the minute, the seconds, the weekday, the month and day, and the year each take their own font, and their own bold, italic and underline. Sizes stay worked out by the app.
+* The clock does not fidget. Each field is sized from the widest text it could ever show, so 11:11 is drawn at the same size and in the same place as 88:88 and nothing shifts as the digits change.
+* Settings, opened with a long press on the clock: show seconds on or off, date format (Jul 12 or 07-12), the fonts and decorations above, and start-when-charging on or off.
 
 Built small and plain
 


### PR DESCRIPTION
The store description still described 0.2.0.

- It claimed the hour and minute **are** bold. That stopped being fixed in 0.3.2 and has been a default you can turn off since 0.3.3.
- It described the burn-in drift as it was before it was widened.
- It said nothing about the fonts, which are the largest thing the app has gained.

Now the bold line says what it actually is, the burn-in line describes moving a few pixels on the minute around a wide disc, and three bullets cover fonts you supply, a font and decorations per field, and sizes taken from the widest text a field could ever show so the clock does not fidget.

Checked rather than assumed: the “APK well under 100 KB” claim still holds at 69 KB; the short description is unchanged and still inside the 80-character limit; the full description is 3138 characters against the 4000 allowed.

**Metadata only** — no build input is touched, the binary is unchanged, and no release is needed. F-Droid reads this tree at a build commit, so it reaches the store with whatever ships next.